### PR TITLE
Create Google Sheets powered reading list page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Radek czyta</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo" aria-label="Logo Radek czyta">Radek czyta</div>
+      <p class="tagline">
+        Lista książek, które właśnie pochłaniam, czekają w kolejce lub już są na
+        półce przeczytane.
+      </p>
+    </header>
+
+    <main>
+      <section class="status-message" id="status-message" role="status" aria-live="polite">
+        Ładuję dane z arkusza...
+      </section>
+
+      <section class="books-section" aria-labelledby="reading-now">
+        <h2 id="reading-now">Teraz czytam</h2>
+        <ul id="reading-list" class="book-list" aria-live="polite"></ul>
+        <p class="empty-message" data-for="reading-list" hidden>
+          Brak książek w tej sekcji.
+        </p>
+      </section>
+
+      <section class="books-section" aria-labelledby="next-up">
+        <h2 id="next-up">Następne</h2>
+        <ul id="next-list" class="book-list" aria-live="polite"></ul>
+        <p class="empty-message" data-for="next-list" hidden>
+          Brak książek w tej sekcji.
+        </p>
+      </section>
+
+      <section class="books-section" aria-labelledby="finished">
+        <h2 id="finished">Przeczytane</h2>
+        <ul id="finished-list" class="book-list" aria-live="polite"></ul>
+        <p class="empty-message" data-for="finished-list" hidden>
+          Brak książek w tej sekcji.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      Aktualizowane automatycznie z Google Sheets.
+    </footer>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,198 @@
+const SHEET_CSV_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tVn8/pub?gid=2028690260&single=true&output=csv";
+
+const lists = {
+  reading: document.getElementById("reading-list"),
+  next: document.getElementById("next-list"),
+  finished: document.getElementById("finished-list"),
+};
+
+const emptyMessages = {
+  reading: document.querySelector('[data-for="reading-list"]'),
+  next: document.querySelector('[data-for="next-list"]'),
+  finished: document.querySelector('[data-for="finished-list"]'),
+};
+
+const statusElement = document.getElementById("status-message");
+
+function setStatusMessage(text, type = "info") {
+  if (!statusElement) {
+    return;
+  }
+  if (!text) {
+    statusElement.hidden = true;
+    return;
+  }
+  statusElement.hidden = false;
+  statusElement.textContent = text;
+  statusElement.classList.toggle("is-error", type === "error");
+}
+
+function parseCSV(text) {
+  const rows = [];
+  let current = "";
+  let row = [];
+  let insideQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === "\"") {
+      const nextChar = text[i + 1];
+      if (insideQuotes && nextChar === "\"") {
+        current += "\"";
+        i += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === "," && !insideQuotes) {
+      row.push(current);
+      current = "";
+    } else if ((char === "\n" || char === "\r") && !insideQuotes) {
+      if (char === "\r" && text[i + 1] === "\n") {
+        // Skip the next \n in Windows-style line endings
+        i += 1;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  if (current || row.length) {
+    row.push(current);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function normalizeStatus(value) {
+  if (!value) {
+    return "";
+  }
+  return value
+    .toString()
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+function bucketForStatus(status) {
+  const normalized = normalizeStatus(status);
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes("czytam")) {
+    return "reading";
+  }
+  if (normalized.includes("planuje")) {
+    return "next";
+  }
+  if (normalized.includes("przeczyt")) {
+    return "finished";
+  }
+  return null;
+}
+
+function createBookCard({ title, author, genre }) {
+  const item = document.createElement("li");
+  item.className = "book-card";
+
+  const titleElement = document.createElement("h3");
+  titleElement.className = "book-title";
+  titleElement.textContent = title || "(bez tytułu)";
+  item.appendChild(titleElement);
+
+  const metaElement = document.createElement("p");
+  metaElement.className = "book-meta";
+
+  if (author) {
+    const authorSpan = document.createElement("span");
+    authorSpan.textContent = author;
+    metaElement.appendChild(authorSpan);
+  }
+
+  if (genre) {
+    const genreSpan = document.createElement("span");
+    genreSpan.textContent = genre;
+    metaElement.appendChild(genreSpan);
+  }
+
+  if (metaElement.childElementCount > 0) {
+    item.appendChild(metaElement);
+  }
+
+  return item;
+}
+
+function toggleEmptyMessage(listKey) {
+  const list = lists[listKey];
+  const message = emptyMessages[listKey];
+  if (!list || !message) {
+    return;
+  }
+  if (list.children.length === 0) {
+    message.hidden = false;
+  } else {
+    message.hidden = true;
+  }
+}
+
+async function loadBooks() {
+  try {
+    setStatusMessage("Ładuję dane z arkusza...");
+    const response = await fetch(SHEET_CSV_URL, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Nie udało się pobrać danych (status ${response.status}).`);
+    }
+    const csvText = await response.text();
+    const rows = parseCSV(csvText).filter((row) =>
+      row.some((cell) => cell && cell.trim() !== "")
+    );
+
+    if (rows.length === 0) {
+      throw new Error("Arkusz nie zawiera żadnych danych.");
+    }
+
+    // Zakładamy, że pierwszy wiersz to nagłówki.
+    const dataRows = rows.slice(1);
+    let itemsLoaded = 0;
+
+    dataRows.forEach((row) => {
+      const title = row[2] ? row[2].trim() : "";
+      const author = row[3] ? row[3].trim() : "";
+      const genre = row[4] ? row[4].trim() : "";
+      const status = row[5] ? row[5].trim() : "";
+
+      const bucket = bucketForStatus(status);
+      if (!bucket || !lists[bucket]) {
+        return;
+      }
+
+      const card = createBookCard({ title, author, genre });
+      lists[bucket].appendChild(card);
+      itemsLoaded += 1;
+    });
+
+    ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+
+    const message =
+      itemsLoaded > 0
+        ? `Zaktualizowano: ${new Date().toLocaleString("pl-PL")}.`
+        : "Brak danych do wyświetlenia.";
+    setStatusMessage(message);
+  } catch (error) {
+    console.error(error);
+    setStatusMessage(
+      "Nie udało się pobrać danych z arkusza. Spróbuj odświeżyć stronę później.",
+      "error"
+    );
+    ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+  }
+}
+
+loadBooks();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: light;
+  font-family: "Nunito", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  --bg-gradient: linear-gradient(135deg, #f4f1fb 0%, #f8f7ff 40%, #eaf8fb 100%);
+  --text-color: #2d2a44;
+  --muted-color: #6c6784;
+  --accent-color: #5145cd;
+  --card-bg: rgba(255, 255, 255, 0.78);
+  --card-border: rgba(81, 69, 205, 0.12);
+  --shadow-soft: 0 12px 32px rgba(51, 51, 102, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: clamp(1.5rem, 3vw, 3rem) 1.5rem 2.5rem;
+}
+
+.site-header {
+  text-align: center;
+  max-width: 720px;
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+}
+
+.logo {
+  font-size: clamp(2.5rem, 5vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-color);
+}
+
+.tagline {
+  margin-top: 0.75rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: var(--muted-color);
+}
+
+main {
+  width: min(960px, 100%);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.status-message {
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--card-border);
+  border-radius: 14px;
+  padding: 0.85rem 1.1rem;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  box-shadow: var(--shadow-soft);
+}
+
+.status-message.is-error {
+  color: #9c1f1f;
+  background: rgba(244, 143, 177, 0.22);
+  border-color: rgba(244, 143, 177, 0.5);
+}
+
+.books-section {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: clamp(1.6rem, 3vw, 2rem);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(6px);
+}
+
+.books-section h2 {
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--accent-color);
+}
+
+.book-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.book-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.book-card:hover,
+.book-card:focus-within {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 28px rgba(81, 69, 205, 0.15);
+}
+
+.book-title {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.book-meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+}
+
+.book-meta span::before {
+  content: "•";
+  margin-right: 0.45rem;
+  color: rgba(81, 69, 205, 0.55);
+}
+
+.book-meta span:first-child::before {
+  content: "";
+  margin: 0;
+}
+
+.empty-message {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  text-align: center;
+}
+
+.empty-message[hidden] {
+  display: none;
+}
+
+.site-footer {
+  margin-top: 3rem;
+  font-size: 0.85rem;
+  color: rgba(45, 42, 68, 0.6);
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  body {
+    padding: 1.5rem 1.2rem 2.5rem;
+  }
+
+  .books-section {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static "Radek czyta" homepage with logo and three book sections
- style the layout with a pastel gradient, cards, and responsive spacing
- fetch Google Sheet CSV data in JavaScript, categorize by status, and show friendly empty/error states

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc3ca3278c832b9c991f5fe75f9618