### PR TITLE
Add book covers next to book details

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,14 +98,34 @@ function bucketForStatus(status) {
   return null;
 }
 
-function createBookCard({ title, author, genre }) {
+function createBookCard({ title, author, genre, coverUrl }) {
   const item = document.createElement("li");
   item.className = "book-card";
+
+  if (coverUrl) {
+    const coverWrapper = document.createElement("div");
+    coverWrapper.className = "book-cover-wrapper";
+
+    const coverImage = document.createElement("img");
+    coverImage.className = "book-cover";
+    coverImage.src = coverUrl;
+    coverImage.alt = title
+      ? `Okładka książki \"${title}\"`
+      : "Okładka książki";
+    coverImage.loading = "lazy";
+    coverImage.decoding = "async";
+
+    coverWrapper.appendChild(coverImage);
+    item.appendChild(coverWrapper);
+  }
+
+  const detailsElement = document.createElement("div");
+  detailsElement.className = "book-details";
 
   const titleElement = document.createElement("h3");
   titleElement.className = "book-title";
   titleElement.textContent = title || "(bez tytułu)";
-  item.appendChild(titleElement);
+  detailsElement.appendChild(titleElement);
 
   const metaElement = document.createElement("p");
   metaElement.className = "book-meta";
@@ -123,8 +143,10 @@ function createBookCard({ title, author, genre }) {
   }
 
   if (metaElement.childElementCount > 0) {
-    item.appendChild(metaElement);
+    detailsElement.appendChild(metaElement);
   }
+
+  item.appendChild(detailsElement);
 
   return item;
 }
@@ -167,13 +189,14 @@ async function loadBooks() {
       const author = row[3] ? row[3].trim() : "";
       const genre = row[4] ? row[4].trim() : "";
       const status = row[5] ? row[5].trim() : "";
+      const coverUrl = row[9] ? row[9].trim() : "";
 
       const bucket = bucketForStatus(status);
       if (!bucket || !lists[bucket]) {
         return;
       }
 
-      const card = createBookCard({ title, author, genre });
+      const card = createBookCard({ title, author, genre, coverUrl });
       lists[bucket].appendChild(card);
       itemsLoaded += 1;
     });

--- a/styles.css
+++ b/styles.css
@@ -100,12 +100,37 @@ main {
   border: 1px solid rgba(0, 0, 0, 0.04);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.85rem, 2.2vw, 1.35rem);
 }
 
 .book-card:hover,
 .book-card:focus-within {
   transform: translateY(-3px);
   box-shadow: 0 16px 28px rgba(81, 69, 205, 0.15);
+}
+
+.book-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.book-cover-wrapper {
+  flex: 0 0 clamp(72px, 15vw, 102px);
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 10px 24px rgba(81, 69, 205, 0.18);
+  background: linear-gradient(135deg, rgba(81, 69, 205, 0.18), rgba(81, 69, 205, 0.1));
+}
+
+.book-cover {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 2 / 3;
 }
 
 .book-title {
@@ -161,4 +186,9 @@ main {
   .books-section {
     padding: 1.4rem;
   }
+
+  .book-card {
+    padding: 1rem 1.1rem;
+  }
+
 }


### PR DESCRIPTION
## Summary
- fetch cover image URLs from column J of the sheet and include them when building book cards
- render the cover image alongside book information and adjust the DOM structure
- update card styling to support the new side-by-side cover and text layout

## Testing
- not run (static site with no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cc4a7b196c832bae8f1996816aa620