### PR TITLE
Wyróżnij gatunek książki jako tag

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,12 +112,14 @@ function createBookCard({ title, author, genre }) {
 
   if (author) {
     const authorSpan = document.createElement("span");
+    authorSpan.className = "book-author";
     authorSpan.textContent = author;
     metaElement.appendChild(authorSpan);
   }
 
   if (genre) {
     const genreSpan = document.createElement("span");
+    genreSpan.className = "book-genre";
     genreSpan.textContent = genre;
     metaElement.appendChild(genreSpan);
   }

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,7 @@ main {
   margin: 0;
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem 0.75rem;
   font-size: 0.95rem;
   color: var(--muted-color);
@@ -131,6 +132,26 @@ main {
 }
 
 .book-meta span:first-child::before {
+  content: "";
+  margin: 0;
+}
+
+.book-genre {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(81, 69, 205, 0.15);
+  color: var(--accent-color);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  line-height: 1.2;
+  box-shadow: inset 0 0 0 1px rgba(81, 69, 205, 0.25);
+}
+
+.book-genre::before {
   content: "";
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- dodano klasy `book-author` i `book-genre` przy renderowaniu kart książek, aby umożliwić ich niezależne stylowanie
- wystylizowano gatunek książki jako kapsułkowy znacznik, dopasowany do kolorystyki strony

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc4ba3ec50832bba7df70a7f73c7a6