### PR TITLE
Display book ratings with star icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,7 +98,48 @@ function bucketForStatus(status) {
   return null;
 }
 
-function createBookCard({ title, author, genre }) {
+function createRatingElement(ratingValue) {
+  if (ratingValue === undefined || ratingValue === null) {
+    return null;
+  }
+
+  const numericRating = Number.parseFloat(ratingValue);
+  if (!Number.isFinite(numericRating)) {
+    return null;
+  }
+
+  const normalizedRating = Math.max(
+    0,
+    Math.min(5, Math.round(numericRating))
+  );
+
+  if (normalizedRating === 0) {
+    return null;
+  }
+
+  const ratingElement = document.createElement("div");
+  ratingElement.className = "book-rating";
+  ratingElement.setAttribute("role", "img");
+  ratingElement.setAttribute(
+    "aria-label",
+    `Ocena: ${normalizedRating} na 5`
+  );
+
+  for (let i = 1; i <= 5; i += 1) {
+    const star = document.createElement("span");
+    star.className = "rating-star";
+    star.textContent = i <= normalizedRating ? "★" : "☆";
+    star.setAttribute("aria-hidden", "true");
+    if (i <= normalizedRating) {
+      star.classList.add("is-filled");
+    }
+    ratingElement.appendChild(star);
+  }
+
+  return ratingElement;
+}
+
+function createBookCard({ title, author, genre, rating }) {
   const item = document.createElement("li");
   item.className = "book-card";
 
@@ -124,6 +165,11 @@ function createBookCard({ title, author, genre }) {
 
   if (metaElement.childElementCount > 0) {
     item.appendChild(metaElement);
+  }
+
+  const ratingElement = createRatingElement(rating);
+  if (ratingElement) {
+    item.appendChild(ratingElement);
   }
 
   return item;
@@ -167,13 +213,14 @@ async function loadBooks() {
       const author = row[3] ? row[3].trim() : "";
       const genre = row[4] ? row[4].trim() : "";
       const status = row[5] ? row[5].trim() : "";
+      const rating = row[8] ? row[8].trim() : "";
 
       const bucket = bucketForStatus(status);
       if (!bucket || !lists[bucket]) {
         return;
       }
 
-      const card = createBookCard({ title, author, genre });
+      const card = createBookCard({ title, author, genre, rating });
       lists[bucket].appendChild(card);
       itemsLoaded += 1;
     });

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,8 @@
   --card-bg: rgba(255, 255, 255, 0.78);
   --card-border: rgba(81, 69, 205, 0.12);
   --shadow-soft: 0 12px 32px rgba(51, 51, 102, 0.08);
+  --star-filled: #5145cd;
+  --star-outline: #c7c2f6;
 }
 
 * {
@@ -133,6 +135,26 @@ main {
 .book-meta span:first-child::before {
   content: "";
   margin: 0;
+}
+
+.book-rating {
+  margin-top: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 1.2rem;
+  color: var(--star-outline);
+}
+
+.rating-star {
+  color: var(--star-outline);
+  line-height: 1;
+  filter: drop-shadow(0 2px 4px rgba(81, 69, 205, 0.08));
+}
+
+.rating-star.is-filled {
+  color: var(--star-filled);
+  filter: drop-shadow(0 3px 10px rgba(81, 69, 205, 0.25));
 }
 
 .empty-message {


### PR DESCRIPTION
## Summary
- parse the rating from column I of the sheet and pass it into the rendered book cards
- render accessible star icons that reflect the 1–5 rating value
- style the stars to match the existing purple palette and subtle shadows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd7616a198832b944be3b7fef972fd