### PR TITLE
Add support for book covers and flexible CSV parsing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,36 @@ main {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.book-card-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.book-cover {
+  flex: 0 0 auto;
+  width: clamp(64px, 14vw, 88px);
+  aspect-ratio: 2 / 3;
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(81, 69, 205, 0.08);
+  box-shadow: 0 10px 20px rgba(81, 69, 205, 0.15);
+}
+
+.book-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.book-card-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .book-card:hover,
 .book-card:focus-within {
   transform: translateY(-3px);
@@ -182,5 +212,13 @@ main {
 
   .books-section {
     padding: 1.4rem;
+  }
+
+  .book-card-body {
+    gap: 0.85rem;
+  }
+
+  .book-cover {
+    width: 64px;
   }
 }


### PR DESCRIPTION
## Summary
- normalize Google Sheet headers so title, author, genre, status, rating and cover columns can move without breaking the UI
- render the optional book cover beside the text content while keeping the star-rating component intact
- introduce supporting styles for the new layout and make the card responsive on smaller screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd93675a80832b9a885010677dbfb4