### PR TITLE
Display book covers from Google Sheet column J

### DIFF
--- a/script.js
+++ b/script.js
@@ -267,7 +267,11 @@ async function loadBooks() {
       author: findColumnIndex(headerRow, ["autor", "author"], 3),
       genre: findColumnIndex(headerRow, ["gatun", "genre"], 4),
       status: findColumnIndex(headerRow, ["status"], 5),
-      coverUrl: findColumnIndex(headerRow, ["oklad", "cover", "obraz", "image"], -1),
+      coverUrl: findColumnIndex(
+        headerRow,
+        ["oklad", "cover", "obraz", "image"],
+        9 // kolumna J w arkuszu (0-index = 9)
+      ),
       rating: findColumnIndex(headerRow, ["ocen", "rating"], -1),
     };
 


### PR DESCRIPTION
## Summary
- use column J as the fallback when resolving cover image URLs in the sheet
- document the fallback to the cover column for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9791eeb0832b9781f47880db38c9