### PR TITLE
Add book edition links to book cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -381,7 +381,7 @@ async function loadBooks() {
       ),
       englishLink: findColumnIndex(
         headerRow,
-        ["link ang", "angiel", "english", "en"],
+        ["link ang", "angiel", "wersja ang", "ksiazka po ang", "english", "en"],
         11
       ),
     };

--- a/styles.css
+++ b/styles.css
@@ -174,27 +174,29 @@ main {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(81, 69, 205, 0.08);
   color: var(--accent-color);
   text-decoration: none;
   font-size: 0.82rem;
   font-weight: 600;
   letter-spacing: 0.01em;
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: color 0.2s ease;
 }
 
 .book-meta-link:hover,
 .book-meta-link:focus {
-  background: rgba(81, 69, 205, 0.18);
   color: var(--accent-color);
-  transform: translateY(-1px);
 }
 
 .book-meta-link:focus {
   outline: 2px solid rgba(81, 69, 205, 0.35);
   outline-offset: 2px;
+}
+
+.book-meta-link:hover .book-meta-link-label,
+.book-meta-link:focus .book-meta-link-label {
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.15em;
 }
 
 .book-meta-link-flag {


### PR DESCRIPTION
## Summary
- read Polish and English book URLs from the Google Sheet export
- render sanitized external links beneath each author when data is available
- style the language link badges to match the existing book card look and feel

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cec0ec2980832bbe2568037630b28b