### PR TITLE
Replace dynamic sheet column lookup with static indices

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -178,6 +178,48 @@ main {
   line-height: 1.2;
 }
 
+.book-meta-links {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.book-meta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(81, 69, 205, 0.1);
+  color: var(--accent-color);
+  text-decoration: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.book-meta-link:hover,
+.book-meta-link:focus-visible {
+  background: rgba(81, 69, 205, 0.18);
+  color: var(--accent-color);
+  transform: translateY(-1px);
+}
+
+.book-meta-link:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.book-meta-link-flag {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.book-meta-link-label {
+  line-height: 1;
+}
+
 .book-rating {
   margin-top: 0.8rem;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- hard-code the Google Sheet column indices expected by the updated worksheet, including new link columns
- remove the now-unused `findColumnIndex` helper since the sheet layout is fixed

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d26653c388832b8c8fe3e6b6c26ca4