### PR TITLE
Adjust book list layout responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -94,8 +94,10 @@ main {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
+  align-items: stretch;
 }
 
 .book-card {
@@ -105,6 +107,8 @@ main {
   border: 1px solid rgba(0, 0, 0, 0.04);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  flex: 1 1 min(320px, 100%);
+  min-width: min(260px, 100%);
 }
 
 .book-card-body {
@@ -223,6 +227,15 @@ main {
 
   .books-section {
     padding: 1.4rem;
+  }
+
+  .book-list {
+    flex-direction: column;
+  }
+
+  .book-card {
+    flex: 1 1 auto;
+    min-width: 100%;
   }
 
   .book-card-body {


### PR DESCRIPTION
## Summary
- convert book list sections to flex layouts so cards can sit side by side when space allows
- let individual book cards grow to fill available width while keeping a sensible minimum size
- keep the single-column layout on narrow screens with dedicated media query overrides

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d170d93330832b8d83da8a50170aa2