### PR TITLE
Adjust book list layout to be responsive

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,7 @@ main {
   padding: 0;
   display: grid;
   gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .book-card {


### PR DESCRIPTION
## Summary
- update the book list styling to use a responsive CSS grid
- allow individual book cards to sit next to each other when there is enough width while keeping a single column on narrow screens

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d170d93330832b8d83da8a50170aa2