### PR TITLE
Align header content with book sections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -60,8 +60,9 @@ body {
 }
 
 .site-header {
-  align-self: stretch;
+  align-self: center;
   width: min(960px, 100%);
+  margin-inline: auto;
   display: flex;
   flex-direction: column;
   gap: clamp(0.75rem, 2vw, 1.25rem);


### PR DESCRIPTION
## Summary
- center the page header container so the logo and tagline align with the book section cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d516a1b210832b9755c689640e2861