### PR TITLE
Fix favicon link duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="/favicon.png" type="image/png" sizes="32x32" />
+    <link rel="icon" href="favicon.png" type="image/png" sizes="32x32" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- update the secondary favicon link to use the same relative path as the primary entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12120e95c832b852abaea14302341