### PR TITLE
Remove duplicate favicon link on about page

### DIFF
--- a/o-mnie/index.html
+++ b/o-mnie/index.html
@@ -11,7 +11,6 @@
       href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="/favicon.png" type="image/png" sizes="32x32" />
     <link rel="stylesheet" href="../styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- remove the redundant favicon link from the about page so the icon is loaded via a relative path

## Testing
- curl -I http://127.0.0.1:8000/favicon.png

------
https://chatgpt.com/codex/tasks/task_e_68e236d2e468832bba2cfeacabbfd7dc