### PR TITLE
Render fractional book ratings with partial stars

### DIFF
--- a/script.js
+++ b/script.js
@@ -139,31 +139,53 @@ function createRatingElement(ratingValue) {
     return null;
   }
 
-  const normalizedRating = Math.max(
-    0,
-    Math.min(5, Math.round(numericRating))
-  );
+  const roundedRating = Math.round(numericRating * 4) / 4;
+  const normalizedRating = Math.max(0, Math.min(5, roundedRating));
 
   if (normalizedRating === 0) {
     return null;
   }
+
+  const fractionalPart = normalizedRating - Math.trunc(normalizedRating);
+  let fractionDigits = 0;
+  if (fractionalPart === 0.5) {
+    fractionDigits = 1;
+  } else if (fractionalPart !== 0) {
+    fractionDigits = 2;
+  }
+
+  const localizedRating = normalizedRating.toLocaleString("pl-PL", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
 
   const ratingElement = document.createElement("div");
   ratingElement.className = "book-rating";
   ratingElement.setAttribute("role", "img");
   ratingElement.setAttribute(
     "aria-label",
-    `Ocena: ${normalizedRating} na 5`
+    `Ocena: ${localizedRating} na 5`
   );
+  ratingElement.setAttribute("title", `Ocena: ${localizedRating} / 5`);
 
   for (let i = 1; i <= 5; i += 1) {
     const star = document.createElement("span");
     star.className = "rating-star";
-    star.textContent = i <= normalizedRating ? "★" : "☆";
     star.setAttribute("aria-hidden", "true");
-    if (i <= normalizedRating) {
-      star.classList.add("is-filled");
-    }
+
+    const baseStar = document.createElement("span");
+    baseStar.className = "rating-star-base";
+    baseStar.textContent = "☆";
+
+    const fillStar = document.createElement("span");
+    fillStar.className = "rating-star-fill";
+    fillStar.textContent = "★";
+
+    const starFill = Math.max(0, Math.min(1, normalizedRating - (i - 1)));
+    const fillPercent = Math.round(starFill * 100);
+    fillStar.style.setProperty("--star-fill", `${fillPercent}%`);
+
+    star.append(baseStar, fillStar);
     ratingElement.appendChild(star);
   }
 

--- a/styles.css
+++ b/styles.css
@@ -412,7 +412,7 @@ main {
   margin-top: 0.8rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.3rem;
   font-size: 1.2rem;
   color: var(--star-outline);
 }
@@ -422,14 +422,39 @@ main {
 }
 
 .rating-star {
-  color: var(--star-outline);
+  position: relative;
+  display: inline-block;
+  width: 1.1em;
+  height: 1.1em;
+  font-size: 1em;
   line-height: 1;
-  filter: drop-shadow(0 2px 4px rgba(81, 69, 205, 0.08));
+  color: inherit;
 }
 
-.rating-star.is-filled {
+.rating-star-base,
+.rating-star-fill {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: inherit;
+  line-height: 1;
+}
+
+.rating-star-base {
+  color: var(--star-outline);
+  filter: drop-shadow(0 2px 4px rgba(81, 69, 205, 0.08));
+  z-index: 0;
+}
+
+.rating-star-fill {
   color: var(--star-filled);
+  overflow: hidden;
+  width: var(--star-fill, 0%);
   filter: drop-shadow(0 3px 10px rgba(81, 69, 205, 0.25));
+  z-index: 1;
+  justify-content: flex-start;
 }
 
 .empty-message {


### PR DESCRIPTION
## Summary
- round spreadsheet ratings to the nearest quarter star and expose localized labels
- render each star with layered elements so quarter, half and three-quarter fills display correctly
- update rating styles to clip the fill layer and preserve drop shadows for partially filled stars

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e38afe04a0832b9639402f7dc8bc95