### PR TITLE
Link book titles to external store

### DIFF
--- a/script.js
+++ b/script.js
@@ -213,69 +213,31 @@ function sanitizeExternalLink(value) {
   }
 }
 
-function createBookLink(urlValue, { label, flagEmoji }) {
-  const sanitizedUrl = sanitizeExternalLink(urlValue);
-  if (!sanitizedUrl) {
+function getPreferredBookLink({ languageValue, polishLink, englishLink }) {
+  const sanitizedPolishLink = sanitizeExternalLink(polishLink);
+  const sanitizedEnglishLink = sanitizeExternalLink(englishLink);
+
+  if (!sanitizedPolishLink && !sanitizedEnglishLink) {
     return null;
   }
 
-  const linkElement = document.createElement("a");
-  linkElement.className = "book-meta-link";
-  linkElement.href = sanitizedUrl;
-  linkElement.target = "_blank";
-  linkElement.rel = "noopener noreferrer";
-  linkElement.setAttribute(
-    "aria-label",
-    `${label} (otwiera się w nowej karcie)`
-  );
-  linkElement.title = `${label} (otwiera się w nowej karcie)`;
+  const normalizedLanguage = normalizeText(languageValue);
+  const prefersEnglish = normalizedLanguage.includes("ang") || normalizedLanguage.includes("eng");
+  const prefersPolish = normalizedLanguage.includes("pol");
 
-  if (flagEmoji) {
-    const flagSpan = document.createElement("span");
-    flagSpan.className = "book-meta-link-flag";
-    flagSpan.textContent = flagEmoji;
-    flagSpan.setAttribute("aria-hidden", "true");
-    linkElement.appendChild(flagSpan);
+  if (prefersEnglish && sanitizedEnglishLink) {
+    return sanitizedEnglishLink;
   }
 
-  const labelSpan = document.createElement("span");
-  labelSpan.className = "book-meta-link-label";
-  labelSpan.textContent = label;
-  linkElement.appendChild(labelSpan);
-
-  return linkElement;
-}
-
-function createBookLinks(polishLink, englishLink) {
-  const links = [];
-
-  const polishLinkElement = createBookLink(polishLink, {
-    label: "Książka po polsku",
-    flagEmoji: "🇵🇱",
-  });
-  if (polishLinkElement) {
-    links.push(polishLinkElement);
+  if (prefersPolish && sanitizedPolishLink) {
+    return sanitizedPolishLink;
   }
 
-  const englishLinkElement = createBookLink(englishLink, {
-    label: "Książka po angielsku",
-    flagEmoji: "🇬🇧",
-  });
-  if (englishLinkElement) {
-    links.push(englishLinkElement);
+  if (sanitizedPolishLink) {
+    return sanitizedPolishLink;
   }
 
-  if (links.length === 0) {
-    return null;
-  }
-
-  const container = document.createElement("span");
-  container.className = "book-meta-links";
-  links.forEach((linkElement) => {
-    container.appendChild(linkElement);
-  });
-
-  return container;
+  return sanitizedEnglishLink;
 }
 
 function getFormatDisplay(formatValue) {
@@ -481,7 +443,30 @@ function createBookCard(
 
   const titleElement = document.createElement("h3");
   titleElement.className = "book-title";
-  titleElement.textContent = title || "(bez tytułu)";
+  const bookTitle = title || "(bez tytułu)";
+  const preferredLink = getPreferredBookLink({
+    languageValue: language,
+    polishLink,
+    englishLink,
+  });
+
+  if (preferredLink) {
+    const titleLink = document.createElement("a");
+    titleLink.className = "book-title-link";
+    titleLink.href = preferredLink;
+    titleLink.target = "_blank";
+    titleLink.rel = "noopener noreferrer";
+    titleLink.textContent = bookTitle;
+    titleLink.setAttribute(
+      "aria-label",
+      `${bookTitle} – otwiera się w nowej karcie`
+    );
+    titleLink.title = `${bookTitle} (otwiera się w nowej karcie)`;
+    titleElement.appendChild(titleLink);
+  } else {
+    titleElement.textContent = bookTitle;
+  }
+
   contentElement.appendChild(titleElement);
 
   const metaElement = document.createElement("p");
@@ -497,11 +482,6 @@ function createBookCard(
   const consumptionElement = createConsumptionElement(format, language);
   if (consumptionElement) {
     metaElement.appendChild(consumptionElement);
-  }
-
-  const linksElement = createBookLinks(polishLink, englishLink);
-  if (linksElement) {
-    metaElement.appendChild(linksElement);
   }
 
   if (genre) {

--- a/styles.css
+++ b/styles.css
@@ -335,6 +335,25 @@ main {
   color: var(--text-color);
 }
 
+.book-title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.book-title-link:hover,
+.book-title-link:focus {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.15em;
+}
+
+.book-title-link:focus {
+  outline: 2px solid rgba(81, 69, 205, 0.35);
+  outline-offset: 3px;
+}
+
 
 .book-meta {
   margin: 0;
@@ -356,54 +375,6 @@ main {
 
 .book-meta-author {
   color: inherit;
-}
-
-.book-meta-links {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.book-card--reading .book-meta-links {
-  justify-content: center;
-}
-
-.book-meta-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--accent-color);
-  text-decoration: none;
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition: color 0.2s ease;
-}
-
-.book-meta-link:hover,
-.book-meta-link:focus {
-  color: var(--accent-color);
-}
-
-.book-meta-link:focus {
-  outline: 2px solid rgba(81, 69, 205, 0.35);
-  outline-offset: 2px;
-}
-
-.book-meta-link:hover .book-meta-link-label,
-.book-meta-link:focus .book-meta-link-label {
-  text-decoration: underline;
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.15em;
-}
-
-.book-meta-link-flag {
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.book-meta-link-label {
-  line-height: 1;
 }
 
 .book-meta-consumption {


### PR DESCRIPTION
## Summary
- turn each book title into an external bookstore link that opens in a new tab and respects the sheet's language-specific URL
- remove the redundant language-specific bookstore badges from the book metadata
- add styling for linked titles and clean up the unused bookstore link styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efe0652aa4832bb96c215aada5fabe