### PR TITLE
Add bilingual support with translation module

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
     <link rel="icon" href="favicon.png" type="image/png" sizes="32x32" />
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
+  <body data-page="home">
     <header class="site-header">
       <div class="site-header-top">
         <div class="logo-container">
-          <a class="logo-link" href="./" aria-label="Strona główna Radek czyta">
+          <a class="logo-link" href="./" data-i18n-attrs="aria-label:common.logoLinkAria">
             <img
               src="radek-czyta.png"
               width="180"
@@ -26,52 +26,75 @@
               alt="Ilustracja logo Radek czyta"
               class="logo-image"
               loading="lazy"
+              data-i18n-attrs="alt:common.logoAlt"
             />
           </a>
           <div class="logo-text-group">
-            <a class="logo" href="./">Radek czyta</a>
-            <p class="tagline">
+            <a class="logo" href="./" data-i18n="common.logoText">Radek czyta</a>
+            <p class="tagline" data-i18n="common.tagline">
               Lista książek, które właśnie pochłaniam, czekają w kolejce lub już są na
               półce przeczytane.
             </p>
           </div>
         </div>
-        <a class="site-nav-link" href="o-mnie/">O mnie</a>
+        <nav class="site-nav">
+          <a class="site-nav-link" href="o-mnie/" data-i18n="navigation.about">O mnie</a>
+          <button
+            type="button"
+            class="language-toggle"
+            data-language-toggle
+          >
+            <span
+              class="language-toggle-flag"
+              data-language-toggle-flag
+              aria-hidden="true"
+            ></span>
+            <span class="language-toggle-label" data-language-toggle-label>EN</span>
+          </button>
+        </nav>
       </div>
     </header>
 
     <main>
-      <section class="status-message" id="status-message" role="status" aria-live="polite">
+      <section
+        class="status-message"
+        id="status-message"
+        role="status"
+        aria-live="polite"
+        data-i18n="home.status.loading"
+      >
         Ładuję dane z arkusza...
       </section>
 
       <section class="books-section" aria-labelledby="reading-now">
-        <h2 id="reading-now">Teraz czytam</h2>
+        <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
         <ul id="reading-list" class="book-list" aria-live="polite"></ul>
-        <p class="empty-message" data-for="reading-list" hidden>
+        <p class="empty-message" data-for="reading-list" hidden data-i18n="home.empty">
           Brak książek w tej sekcji.
         </p>
       </section>
 
       <section class="books-section" aria-labelledby="next-up">
-        <h2 id="next-up">Następne</h2>
+        <h2 id="next-up" data-i18n="home.sections.next">Następne</h2>
         <ul id="next-list" class="book-list" aria-live="polite"></ul>
-        <p class="empty-message" data-for="next-list" hidden>
+        <p class="empty-message" data-for="next-list" hidden data-i18n="home.empty">
           Brak książek w tej sekcji.
         </p>
       </section>
 
       <section class="books-section" aria-labelledby="finished">
-        <h2 id="finished">Przeczytane</h2>
+        <h2 id="finished" data-i18n="home.sections.finished">Przeczytane</h2>
         <ul id="finished-list" class="book-list" aria-live="polite"></ul>
-        <p class="empty-message" data-for="finished-list" hidden>
+        <p class="empty-message" data-for="finished-list" hidden data-i18n="home.empty">
           Brak książek w tej sekcji.
         </p>
       </section>
     </main>
 
     <footer class="site-footer">
-      <p class="site-footer-text">Aktualizowane automatycznie z Google Sheets.</p>
+      <p class="site-footer-text" data-i18n="footers.home">
+        Aktualizowane automatycznie z Google Sheets.
+      </p>
       <p
         class="site-footer-text"
         id="last-updated"
@@ -81,6 +104,7 @@
       ></p>
     </footer>
 
+    <script src="translations.js" defer></script>
     <script src="script.js" defer></script>
   </body>
 </html>

--- a/o-mnie/index.html
+++ b/o-mnie/index.html
@@ -13,14 +13,14 @@
     />
     <link rel="stylesheet" href="../styles.css" />
   </head>
-  <body>
+  <body data-page="about">
     <header class="site-header">
       <div class="site-header-top">
         <div class="logo-container">
           <a
             class="logo-link"
             href="../"
-            aria-label="Strona główna Radek czyta"
+            data-i18n-attrs="aria-label:common.logoLinkAria"
           >
             <img
               src="../radek-czyta.png"
@@ -29,53 +29,70 @@
               alt="Ilustracja logo Radek czyta"
               class="logo-image"
               loading="lazy"
+              data-i18n-attrs="alt:common.logoAlt"
             />
           </a>
           <div class="logo-text-group">
-            <a class="logo" href="../">Radek czyta</a>
-            <p class="tagline">
+            <a class="logo" href="../" data-i18n="common.logoText">Radek czyta</a>
+            <p class="tagline" data-i18n="common.tagline">
               Lista książek, które właśnie pochłaniam, czekają w kolejce lub już są na
               półce przeczytane.
             </p>
           </div>
         </div>
-        <a class="site-nav-link" href="../">Lista książek</a>
+        <nav class="site-nav">
+          <a class="site-nav-link" href="../" data-i18n="navigation.books">Lista książek</a>
+          <button
+            type="button"
+            class="language-toggle"
+            data-language-toggle
+          >
+            <span
+              class="language-toggle-flag"
+              data-language-toggle-flag
+              aria-hidden="true"
+            ></span>
+            <span class="language-toggle-label" data-language-toggle-label>EN</span>
+          </button>
+        </nav>
       </div>
     </header>
 
     <main>
       <section class="books-section about-section" aria-labelledby="about-heading">
-        <h1 id="about-heading">O mnie</h1>
-        <p>
-          Hej, nazywam się Radek Grabarek i na tej stronie pokazuję listę książek
-          jakie ostatnio czytałem, czytam lub planuję przeczytać. Bardzo lubię
-          książki, choć często brakuje mi na nie czasu. Ale tak chyba mają
-          wszystkie mole ksiażkowe, prawda?
+        <h1 id="about-heading" data-i18n="about.heading">O mnie</h1>
+        <p data-i18n="about.paragraph1">
+          Hej, nazywam się Radek Grabarek i na tej stronie pokazuję listę książek jakie
+          ostatnio czytałem, czytam lub planuję przeczytać. Bardzo lubię książki, choć
+          często brakuje mi na nie czasu. Ale tak chyba mają wszystkie mole ksiażkowe,
+          prawda?
         </p>
-        <p>
-          Dla relaksu wybieram science fiction – szczególnie historie osadzone w
-          kosmosie. Fascynują mnie astronomia, astronautyka i inżynieria kosmiczna,
-          więc sięgam też po książki popularnonaukowe w tych tematach. Z pasji do
-          kosmosu prowadzę też kanał YouTube
+        <p data-i18n="about.paragraph2" data-i18n-mode="html">
+          Dla relaksu wybieram science fiction – szczególnie historie osadzone w kosmosie.
+          Fascynują mnie astronomia, astronautyka i inżynieria kosmiczna, więc sięgam też
+          po książki popularnonaukowe w tych tematach. Z pasji do kosmosu prowadzę też
+          kanał YouTube
           <a href="https://www.youtube.com/@wnms" target="_blank" rel="noopener noreferrer"
             ><em>We Need More Space</em></a
-          >, gdzie opowiadam o misjach kosmicznych i dzielę się recenzjami
-          niektórych tytułów.
+          >, gdzie opowiadam o misjach kosmicznych i dzielę się recenzjami niektórych
+          tytułów.
         </p>
-        <p>
-          Od czasu do czasu sięgam również po książki o marketingu, biznesie online
-          czy rozwoju osobistym – wybieram jednak te rzetelne, praktyczne pozycje, a
-          nie “coacherskie” poradniki.
+        <p data-i18n="about.paragraph3">
+          Od czasu do czasu sięgam również po książki o marketingu, biznesie online czy
+          rozwoju osobistym – wybieram jednak te rzetelne, praktyczne pozycje, a nie
+          “coacherskie” poradniki.
         </p>
-        <p>
-          Jak widać jestem z tych, którzy czytają po kilka książek na raz, ale
-          zwykle jest to tylko jedna książka z danego gatunku.
+        <p data-i18n="about.paragraph4">
+          Jak widać jestem z tych, którzy czytają po kilka książek na raz, ale zwykle jest
+          to tylko jedna książka z danego gatunku.
         </p>
       </section>
     </main>
 
     <footer class="site-footer">
-      <p class="site-footer-text">Dzięki za odwiedziny!</p>
+      <p class="site-footer-text" data-i18n="footers.about">Dzięki za odwiedziny!</p>
     </footer>
+
+    <script src="../translations.js" defer></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const SHEET_CSV_URL =
-  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tn8/pub?gid=2028690260&single=true&output=csv";
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tVn8/pub?gid=2028690260&single=true&output=csv";
 
 const SHEET_COLUMN_INDEXES = Object.freeze({
   title: 2, // kolumna C

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const SHEET_CSV_URL =
-  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tVn8/pub?gid=2028690260&single=true&output=csv";
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tn8/pub?gid=2028690260&single=true&output=csv";
 
 const SHEET_COLUMN_INDEXES = Object.freeze({
   title: 2, // kolumna C
@@ -13,6 +13,14 @@ const SHEET_COLUMN_INDEXES = Object.freeze({
   polishLink: 10, // kolumna K
   englishLink: 11, // kolumna L
 });
+
+const STATUS_KEYWORDS = Object.freeze({
+  reading: ["czytam", "czyt", "reading", "current"],
+  next: ["planuje", "plan", "nast", "next", "queue"],
+  finished: ["przeczyt", "skoń", "finished", "read"],
+});
+
+const I18N = window.I18N;
 
 const lists = {
   reading: document.getElementById("reading-list"),
@@ -29,30 +37,73 @@ const emptyMessages = {
 const statusElement = document.getElementById("status-message");
 const lastUpdatedElement = document.getElementById("last-updated");
 
-function setStatusMessage(text, type = "info") {
+const state = {
+  books: [],
+  status: { key: null, params: {}, type: "info" },
+  lastUpdated: null,
+};
+
+function applyStatus() {
   if (!statusElement) {
     return;
   }
-  if (!text) {
+  const { key, params, type } = state.status;
+  if (!key) {
     statusElement.hidden = true;
+    statusElement.textContent = "";
+    statusElement.classList.remove("is-error");
+    return;
+  }
+  const message = I18N.translate(key, params);
+  if (!message) {
+    statusElement.hidden = true;
+    statusElement.textContent = "";
+    statusElement.classList.remove("is-error");
     return;
   }
   statusElement.hidden = false;
-  statusElement.textContent = text;
+  statusElement.textContent = message;
   statusElement.classList.toggle("is-error", type === "error");
 }
 
-function setLastUpdated(text) {
+function showStatus(key, params = {}, type = "info") {
+  state.status = { key, params, type };
+  applyStatus();
+}
+
+function clearStatus() {
+  state.status = { key: null, params: {}, type: "info" };
+  applyStatus();
+}
+
+function applyLastUpdated() {
   if (!lastUpdatedElement) {
     return;
   }
-  if (!text) {
+  if (!state.lastUpdated) {
+    lastUpdatedElement.textContent = "";
+    lastUpdatedElement.hidden = true;
+    return;
+  }
+  const formatted = I18N.formatDateTime(state.lastUpdated);
+  if (!formatted) {
+    lastUpdatedElement.textContent = "";
+    lastUpdatedElement.hidden = true;
+    return;
+  }
+  const label = I18N.translateDynamic("statusUpdated", { date: formatted });
+  if (!label) {
     lastUpdatedElement.textContent = "";
     lastUpdatedElement.hidden = true;
     return;
   }
   lastUpdatedElement.hidden = false;
-  lastUpdatedElement.textContent = text;
+  lastUpdatedElement.textContent = label;
+}
+
+function setLastUpdated(date) {
+  state.lastUpdated = date instanceof Date ? date : null;
+  applyLastUpdated();
 }
 
 function parseCSV(text) {
@@ -76,7 +127,6 @@ function parseCSV(text) {
       current = "";
     } else if ((char === "\n" || char === "\r") && !insideQuotes) {
       if (char === "\r" && text[i + 1] === "\n") {
-        // Skip the next \n in Windows-style line endings
         i += 1;
       }
       row.push(current);
@@ -117,14 +167,10 @@ function bucketForStatus(status) {
   if (!normalized) {
     return null;
   }
-  if (normalized.includes("czytam")) {
-    return "reading";
-  }
-  if (normalized.includes("planuje")) {
-    return "next";
-  }
-  if (normalized.includes("przeczyt")) {
-    return "finished";
+  for (const [bucket, keywords] of Object.entries(STATUS_KEYWORDS)) {
+    if (keywords.some((keyword) => normalized.includes(keyword))) {
+      return bucket;
+    }
   }
   return null;
 }
@@ -154,7 +200,7 @@ function createRatingElement(ratingValue) {
     fractionDigits = 2;
   }
 
-  const localizedRating = normalizedRating.toLocaleString("pl-PL", {
+  const localizedRating = I18N.formatNumber(normalizedRating, {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   });
@@ -162,11 +208,15 @@ function createRatingElement(ratingValue) {
   const ratingElement = document.createElement("div");
   ratingElement.className = "book-rating";
   ratingElement.setAttribute("role", "img");
-  ratingElement.setAttribute(
-    "aria-label",
-    `Ocena: ${localizedRating} na 5`
-  );
-  ratingElement.setAttribute("title", `Ocena: ${localizedRating} / 5`);
+
+  const ariaLabel = I18N.translateDynamic("ratingAria", { value: localizedRating });
+  const title = I18N.translateDynamic("ratingTitle", { value: localizedRating });
+  if (ariaLabel) {
+    ratingElement.setAttribute("aria-label", ariaLabel);
+  }
+  if (title) {
+    ratingElement.setAttribute("title", title);
+  }
 
   for (let i = 1; i <= 5; i += 1) {
     const star = document.createElement("span");
@@ -294,24 +344,27 @@ function getLanguageDisplay(languageValue) {
   }
 
   let flag = "";
-  let readable = displayText;
+  let code = null;
 
   if (normalized.includes("pol")) {
     flag = "🇵🇱";
-    readable = "polski";
+    code = "pl";
   } else if (normalized.includes("ang") || normalized.includes("eng")) {
     flag = "🇬🇧";
-    readable = "angielski";
+    code = "en";
   } else if (normalized.includes("hiszp") || normalized.includes("span")) {
     flag = "🇪🇸";
-    readable = "hiszpański";
+    code = "es";
   } else if (normalized.includes("niem") || normalized.includes("ger")) {
     flag = "🇩🇪";
-    readable = "niemiecki";
+    code = "de";
   } else if (normalized.includes("franc") || normalized.includes("fr")) {
     flag = "🇫🇷";
-    readable = "francuski";
+    code = "fr";
   }
+
+  const languageNames = I18N.translate("languageNames") || {};
+  const readable = (code && languageNames[code]) || displayText;
 
   return {
     flag,
@@ -347,16 +400,22 @@ function createConsumptionElement(formatValue, languageValue) {
 
     formatSpan.append(iconSpan, labelSpan);
     container.appendChild(formatSpan);
-    ariaParts.push(`format: ${formatInfo.label}`);
+
+    const ariaText = I18N.translateDynamic("consumptionFormat", { label: formatInfo.label });
+    if (ariaText) {
+      ariaParts.push(ariaText);
+    }
   }
 
   if (languageInfo) {
     const languageSpan = document.createElement("span");
     languageSpan.className = "book-meta-language";
-    languageSpan.setAttribute(
-      "aria-label",
-      `Język: ${languageInfo.label}`
-    );
+
+    const labelText = languageInfo.flag ? languageInfo.label : languageInfo.originalLabel;
+    const ariaLabel = I18N.translateDynamic("languageAria", { label: labelText });
+    if (ariaLabel) {
+      languageSpan.setAttribute("aria-label", ariaLabel);
+    }
 
     if (languageInfo.flag) {
       const flagSpan = document.createElement("span");
@@ -368,17 +427,23 @@ function createConsumptionElement(formatValue, languageValue) {
 
     const labelSpan = document.createElement("span");
     labelSpan.className = "book-meta-language-label";
-    labelSpan.textContent = languageInfo.flag
-      ? languageInfo.label
-      : languageInfo.originalLabel;
+    labelSpan.textContent = labelText;
     languageSpan.appendChild(labelSpan);
 
     container.appendChild(languageSpan);
-    ariaParts.push(`język: ${languageInfo.label}`);
+
+    const ariaText = I18N.translateDynamic("consumptionLanguage", { label: labelText });
+    if (ariaText) {
+      ariaParts.push(ariaText);
+    }
   }
 
   if (ariaParts.length > 0) {
-    container.setAttribute("aria-label", `Sposób lektury – ${ariaParts.join(", ")}`);
+    const details = ariaParts.join(", ");
+    const combined = I18N.translateDynamic("consumptionLabel", { details });
+    if (combined) {
+      container.setAttribute("aria-label", combined);
+    }
   }
 
   return container;
@@ -400,6 +465,7 @@ function getCellValue(row, index) {
 
 function createBookCard(
   {
+    bucket,
     title,
     author,
     genre,
@@ -415,8 +481,9 @@ function createBookCard(
   const item = document.createElement("li");
   item.className = "book-card";
 
-  if (typeof variant === "string") {
-    const trimmedVariant = variant.trim();
+  const effectiveVariant = variant || bucket;
+  if (typeof effectiveVariant === "string") {
+    const trimmedVariant = effectiveVariant.trim();
     if (trimmedVariant) {
       item.classList.add(`book-card--${trimmedVariant}`);
     }
@@ -431,7 +498,14 @@ function createBookCard(
 
     const coverImage = document.createElement("img");
     coverImage.src = coverUrl;
-    coverImage.alt = title ? `Okładka: ${title}` : "Okładka książki";
+    const fallbackTitle = I18N.getPlaceholder("untitled") || "";
+    const bookTitle = title || fallbackTitle || "";
+    const coverAlt = title
+      ? I18N.translateDynamic("coverAlt", { title: bookTitle })
+      : I18N.translateDynamic("coverAltFallback");
+    if (coverAlt) {
+      coverImage.alt = coverAlt;
+    }
     coverImage.loading = "lazy";
 
     coverWrapper.appendChild(coverImage);
@@ -443,7 +517,8 @@ function createBookCard(
 
   const titleElement = document.createElement("h3");
   titleElement.className = "book-title";
-  const bookTitle = title || "(bez tytułu)";
+  const fallbackTitle = I18N.getPlaceholder("untitled") || "";
+  const bookTitle = title || fallbackTitle || "";
   const preferredLink = getPreferredBookLink({
     languageValue: language,
     polishLink,
@@ -457,11 +532,16 @@ function createBookCard(
     titleLink.target = "_blank";
     titleLink.rel = "noopener noreferrer";
     titleLink.textContent = bookTitle;
-    titleLink.setAttribute(
-      "aria-label",
-      `${bookTitle} – otwiera się w nowej karcie`
-    );
-    titleLink.title = `${bookTitle} (otwiera się w nowej karcie)`;
+
+    const ariaLabel = I18N.translateDynamic("linkAria", { title: bookTitle });
+    const titleText = I18N.translateDynamic("linkTitle", { title: bookTitle });
+    if (ariaLabel) {
+      titleLink.setAttribute("aria-label", ariaLabel);
+    }
+    if (titleText) {
+      titleLink.title = titleText;
+    }
+
     titleElement.appendChild(titleLink);
   } else {
     titleElement.textContent = bookTitle;
@@ -506,6 +586,43 @@ function createBookCard(
   return item;
 }
 
+function clearLists() {
+  Object.values(lists).forEach((list) => {
+    if (list) {
+      list.replaceChildren();
+    }
+  });
+}
+
+function renderBooks() {
+  clearLists();
+  const grouped = {
+    reading: [],
+    next: [],
+    finished: [],
+  };
+
+  state.books.forEach((book) => {
+    if (grouped[book.bucket]) {
+      grouped[book.bucket].push(book);
+    }
+  });
+
+  Object.entries(grouped).forEach(([bucket, items]) => {
+    const list = lists[bucket];
+    if (!list || items.length === 0) {
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    items.forEach((item) => {
+      fragment.appendChild(createBookCard(item, { variant: bucket }));
+    });
+    list.appendChild(fragment);
+  });
+
+  ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+}
+
 function toggleEmptyMessage(listKey) {
   const list = lists[listKey];
   const message = emptyMessages[listKey];
@@ -521,27 +638,28 @@ function toggleEmptyMessage(listKey) {
 
 async function loadBooks() {
   try {
-    setStatusMessage("Ładuję dane z arkusza...");
-    setLastUpdated("");
+    showStatus("home.status.loading");
+    setLastUpdated(null);
     const response = await fetch(SHEET_CSV_URL, { cache: "no-store" });
     if (!response.ok) {
-      throw new Error(`Nie udało się pobrać danych (status ${response.status}).`);
+      const error = new Error("HTTP_ERROR");
+      error.status = response.status;
+      throw error;
     }
+
     const csvText = await response.text();
-    const rows = parseCSV(csvText).filter((row) =>
-      row.some((cell) => cell && cell.trim() !== "")
-    );
+    const rows = parseCSV(csvText).filter((row) => row.some((cell) => cell && cell.trim() !== ""));
 
     if (rows.length === 0) {
-      throw new Error("Arkusz nie zawiera żadnych danych.");
+      const error = new Error("EMPTY_SHEET");
+      error.code = "EMPTY_SHEET";
+      throw error;
     }
 
-    // Zakładamy, że pierwszy wiersz to nagłówki.
     const dataRows = rows.slice(1);
-
     const columnIndexes = SHEET_COLUMN_INDEXES;
 
-    let itemsLoaded = 0;
+    const items = [];
 
     dataRows.forEach((row) => {
       const title = getCellValue(row, columnIndexes.title);
@@ -560,42 +678,57 @@ async function loadBooks() {
         return;
       }
 
-      const card = createBookCard(
-        {
-          title,
-          author,
-          genre,
-          rating,
-          coverUrl,
-          polishLink,
-          englishLink,
-          format,
-          language,
-        },
-        { variant: bucket }
-      );
-      lists[bucket].appendChild(card);
-      itemsLoaded += 1;
+      items.push({
+        bucket,
+        title,
+        author,
+        genre,
+        rating,
+        coverUrl,
+        polishLink,
+        englishLink,
+        format,
+        language,
+      });
     });
 
-    ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+    state.books = items;
+    renderBooks();
 
-    if (itemsLoaded > 0) {
-      setStatusMessage("");
-      setLastUpdated(`Zaktualizowano: ${new Date().toLocaleString("pl-PL")}.`);
+    if (items.length > 0) {
+      clearStatus();
+      setLastUpdated(new Date());
     } else {
-      setStatusMessage("Brak danych do wyświetlenia.");
-      setLastUpdated("");
+      showStatus("home.status.noData");
+      setLastUpdated(null);
     }
   } catch (error) {
     console.error(error);
-    setStatusMessage(
-      "Nie udało się pobrać danych z arkusza. Spróbuj odświeżyć stronę później.",
-      "error"
-    );
-    setLastUpdated("");
-    ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+    state.books = [];
+    renderBooks();
+    setLastUpdated(null);
+    if (error && error.status) {
+      showStatus("dynamic.statusHttpError", { status: error.status }, "error");
+    } else if (error && error.code === "EMPTY_SHEET") {
+      showStatus("home.status.sheetEmpty", {}, "error");
+    } else {
+      showStatus("home.status.fetchError", {}, "error");
+    }
   }
 }
 
-loadBooks();
+if (I18N) {
+  I18N.onReady(() => {
+    applyStatus();
+    applyLastUpdated();
+    loadBooks();
+  });
+
+  I18N.onChange(() => {
+    applyStatus();
+    applyLastUpdated();
+    renderBooks();
+  });
+} else {
+  loadBooks();
+}

--- a/styles.css
+++ b/styles.css
@@ -77,9 +77,55 @@ body {
   flex-wrap: wrap;
 }
 
-.site-header-top .site-nav-link {
+.site-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
   margin-left: auto;
-  align-self: flex-start;
+  flex-shrink: 0;
+}
+
+.site-nav .site-nav-link {
+  margin-left: 0;
+}
+
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(81, 69, 205, 0.18);
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--accent-color);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(81, 69, 205, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  font-family: inherit;
+}
+
+.language-toggle:hover,
+.language-toggle:focus {
+  background: rgba(81, 69, 205, 0.12);
+  box-shadow: 0 12px 28px rgba(81, 69, 205, 0.18);
+  transform: translateY(-1px);
+}
+
+.language-toggle:focus {
+  outline: 2px solid rgba(81, 69, 205, 0.35);
+  outline-offset: 2px;
+}
+
+.language-toggle-flag {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.language-toggle-label {
+  line-height: 1;
 }
 
 .logo-container {

--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,481 @@
+(function () {
+  const LANGUAGE_STORAGE_KEY = "radek-czyta-language";
+
+  const LANGUAGE_METADATA = {
+    pl: { label: "PL", flag: "🇵🇱" },
+    en: { label: "EN", flag: "🇬🇧" },
+  };
+
+  const translations = {
+    pl: {
+      meta: { htmlLang: "pl", locale: "pl-PL" },
+      languageNames: {
+        pl: "polski",
+        en: "angielski",
+        es: "hiszpański",
+        de: "niemiecki",
+        fr: "francuski",
+      },
+      pageTitles: {
+        home: "Radek czyta",
+        about: "O mnie – Radek czyta",
+      },
+      common: {
+        logoText: "Radek czyta",
+        tagline:
+          "Lista książek, które właśnie pochłaniam, czekają w kolejce lub już są na półce przeczytane.",
+        logoLinkAria: "Strona główna Radek czyta",
+        logoAlt: "Ilustracja logo Radek czyta",
+      },
+      navigation: {
+        about: "O mnie",
+        books: "Lista książek",
+      },
+      home: {
+        sections: {
+          reading: "Teraz czytam",
+          next: "Następne",
+          finished: "Przeczytane",
+        },
+        empty: "Brak książek w tej sekcji.",
+        status: {
+          loading: "Ładuję dane z arkusza...",
+          sheetEmpty: "Arkusz nie zawiera żadnych danych.",
+          noData: "Brak danych do wyświetlenia.",
+          fetchError:
+            "Nie udało się pobrać danych z arkusza. Spróbuj odświeżyć stronę później.",
+        },
+      },
+      about: {
+        heading: "O mnie",
+        paragraph1:
+          "Hej, nazywam się Radek Grabarek i na tej stronie pokazuję listę książek jakie ostatnio czytałem, czytam lub planuję przeczytać. Bardzo lubię książki, choć często brakuje mi na nie czasu. Ale tak chyba mają wszystkie mole ksiażkowe, prawda?",
+        paragraph2:
+          'Dla relaksu wybieram science fiction – szczególnie historie osadzone w kosmosie. Fascynują mnie astronomia, astronautyka i inżynieria kosmiczna, więc sięgam też po książki popularnonaukowe w tych tematach. Z pasji do kosmosu prowadzę też kanał YouTube <a href="https://www.youtube.com/@wnms" target="_blank" rel="noopener noreferrer"><em>We Need More Space</em></a>, gdzie opowiadam o misjach kosmicznych i dzielę się recenzjami niektórych tytułów.',
+        paragraph3:
+          "Od czasu do czasu sięgam również po książki o marketingu, biznesie online czy rozwoju osobistym – wybieram jednak te rzetelne, praktyczne pozycje, a nie \u201ccoacherskie\u201d poradniki.",
+        paragraph4:
+          "Jak widać jestem z tych, którzy czytają po kilka książek na raz, ale zwykle jest to tylko jedna książka z danego gatunku.",
+        footer: "Dzięki za odwiedziny!",
+      },
+      footers: {
+        home: "Aktualizowane automatycznie z Google Sheets.",
+        about: "Dzięki za odwiedziny!",
+      },
+      placeholders: {
+        untitled: "(bez tytułu)",
+      },
+      languageToggle: {
+        aria: ({ targetLanguageName }) => `Zmień język na ${targetLanguageName}`,
+        title: ({ targetLanguageName }) => `Zmień język na ${targetLanguageName}`,
+      },
+      dynamic: {
+        ratingAria: ({ value }) => `Ocena: ${value} na 5`,
+        ratingTitle: ({ value }) => `Ocena: ${value} / 5`,
+        coverAlt: ({ title }) => `Okładka: ${title}`,
+        coverAltFallback: "Okładka książki",
+        linkAria: ({ title }) => `${title} – otwiera się w nowej karcie`,
+        linkTitle: ({ title }) => `${title} (otwiera się w nowej karcie)`,
+        consumptionLabel: ({ details }) => `Sposób lektury – ${details}`,
+        consumptionFormat: ({ label }) => `format: ${label}`,
+        consumptionLanguage: ({ label }) => `język: ${label}`,
+        languageAria: ({ label }) => `Język: ${label}`,
+        statusUpdated: ({ date }) => `Zaktualizowano: ${date}.`,
+        statusHttpError: ({ status }) => `Nie udało się pobrać danych (status ${status}).`,
+      },
+    },
+    en: {
+      meta: { htmlLang: "en", locale: "en-GB" },
+      languageNames: {
+        pl: "Polish",
+        en: "English",
+        es: "Spanish",
+        de: "German",
+        fr: "French",
+      },
+      pageTitles: {
+        home: "Radek reads",
+        about: "About – Radek reads",
+      },
+      common: {
+        logoText: "Radek reads",
+        tagline:
+          "A list of books I'm currently devouring, queued up, or already finished.",
+        logoLinkAria: "Radek reads home page",
+        logoAlt: "Radek reads logo illustration",
+      },
+      navigation: {
+        about: "About me",
+        books: "Book list",
+      },
+      home: {
+        sections: {
+          reading: "Currently reading",
+          next: "Up next",
+          finished: "Finished",
+        },
+        empty: "No books in this section.",
+        status: {
+          loading: "Loading data from the sheet...",
+          sheetEmpty: "The sheet does not contain any data.",
+          noData: "No data to display.",
+          fetchError:
+            "Couldn't fetch data from the sheet. Please refresh the page later.",
+        },
+      },
+      about: {
+        heading: "About me",
+        paragraph1:
+          "Hi, I'm Radek Grabarek and on this page I share a list of books I've recently read, am reading or plan to pick up. I love books, even if I often run out of time for them. But that's what bookworms are like, right?",
+        paragraph2:
+          'To unwind I reach for science fiction—especially stories set in space. I'm fascinated by astronomy, astronautics and space engineering, so I also read popular science books on those topics. Driven by this passion I run the YouTube channel <a href="https://www.youtube.com/@wnms" target="_blank" rel="noopener noreferrer"><em>We Need More Space</em></a>, where I talk about space missions and share reviews of selected titles.',
+        paragraph3:
+          "From time to time I also reach for books about marketing, online business or personal development—I go for reliable, practical titles rather than fluffy \"coach\" guides.",
+        paragraph4:
+          "As you can see, I'm the kind of reader who juggles several books at once, though usually just one per genre.",
+        footer: "Thanks for visiting!",
+      },
+      footers: {
+        home: "Automatically updated from Google Sheets.",
+        about: "Thanks for visiting!",
+      },
+      placeholders: {
+        untitled: "(no title)",
+      },
+      languageToggle: {
+        aria: ({ targetLanguageName }) => `Switch language to ${targetLanguageName}`,
+        title: ({ targetLanguageName }) => `Switch language to ${targetLanguageName}`,
+      },
+      dynamic: {
+        ratingAria: ({ value }) => `Rating: ${value} out of 5`,
+        ratingTitle: ({ value }) => `Rating: ${value} / 5`,
+        coverAlt: ({ title }) => `Cover: ${title}`,
+        coverAltFallback: "Book cover",
+        linkAria: ({ title }) => `${title} – opens in a new tab`,
+        linkTitle: ({ title }) => `${title} (opens in a new tab)`,
+        consumptionLabel: ({ details }) => `Reading format – ${details}`,
+        consumptionFormat: ({ label }) => `format: ${label}`,
+        consumptionLanguage: ({ label }) => `language: ${label}`,
+        languageAria: ({ label }) => `Language: ${label}`,
+        statusUpdated: ({ date }) => `Updated: ${date}.`,
+        statusHttpError: ({ status }) => `Failed to fetch data (status ${status}).`,
+      },
+    },
+  };
+
+  const listeners = new Set();
+  const readyListeners = [];
+  let initialized = false;
+  let currentLanguage = null;
+  let currentPage = null;
+  let toggleAttached = false;
+
+  function resolveLanguage(language) {
+    if (!language) {
+      return null;
+    }
+    const lower = language.toLowerCase();
+    if (translations[lower]) {
+      return lower;
+    }
+    const [shortCode] = lower.split("-");
+    if (translations[shortCode]) {
+      return shortCode;
+    }
+    return null;
+  }
+
+  function getStoredLanguage() {
+    try {
+      return window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function storeLanguage(language) {
+    try {
+      window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    } catch (error) {
+      // ignore storage errors
+    }
+  }
+
+  function detectBrowserLanguage() {
+    const nav = window.navigator || {};
+    const preferences = [];
+    if (Array.isArray(nav.languages)) {
+      preferences.push(...nav.languages);
+    }
+    if (nav.language) {
+      preferences.push(nav.language);
+    }
+    if (nav.userLanguage) {
+      preferences.push(nav.userLanguage);
+    }
+    for (const preference of preferences) {
+      const resolved = resolveLanguage(preference);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+
+  function getTranslationObject(language) {
+    return translations[language] || translations.en;
+  }
+
+  function getFromObject(object, path) {
+    if (!object) {
+      return undefined;
+    }
+    const segments = path.split(".");
+    let value = object;
+    for (const segment of segments) {
+      if (value && Object.prototype.hasOwnProperty.call(value, segment)) {
+        value = value[segment];
+      } else {
+        return undefined;
+      }
+    }
+    return value;
+  }
+
+  function translateInternal(language, key, params) {
+    const dictionary = getTranslationObject(language);
+    const rawValue = getFromObject(dictionary, key);
+    if (typeof rawValue === "function") {
+      return rawValue(params || {});
+    }
+    return rawValue;
+  }
+
+  function translate(key, params) {
+    return translateInternal(currentLanguage, key, params);
+  }
+
+  function formatNumber(value, options) {
+    const locale = translateInternal(currentLanguage, "meta.locale") || currentLanguage;
+    return Number(value).toLocaleString(locale, options);
+  }
+
+  function formatDateTime(date) {
+    if (!(date instanceof Date)) {
+      return "";
+    }
+    const locale = translateInternal(currentLanguage, "meta.locale") || currentLanguage;
+    return date.toLocaleString(locale);
+  }
+
+  function setElementContent(element, key) {
+    const mode = element.getAttribute("data-i18n-mode") || "text";
+    const translation = translate(key);
+    if (translation === undefined || translation === null) {
+      return;
+    }
+    if (mode === "html") {
+      element.innerHTML = translation;
+    } else {
+      element.textContent = translation;
+    }
+  }
+
+  function applyAttributeTranslations(element, descriptor) {
+    if (!descriptor) {
+      return;
+    }
+    const pairs = descriptor
+      .split(/[,;]+/)
+      .map((pair) => pair.trim())
+      .filter(Boolean);
+    pairs.forEach((pair) => {
+      const [attr, key] = pair.split(":").map((part) => part.trim());
+      if (!attr || !key) {
+        return;
+      }
+      const translation = translate(key);
+      if (translation === undefined || translation === null) {
+        return;
+      }
+      element.setAttribute(attr, translation);
+    });
+  }
+
+  function updatePageTitle() {
+    if (!currentPage) {
+      return;
+    }
+    const pageTitle = translate(`pageTitles.${currentPage}`);
+    if (pageTitle) {
+      document.title = pageTitle;
+    }
+  }
+
+  function updateHtmlLang() {
+    const htmlLang = translate("meta.htmlLang") || currentLanguage;
+    document.documentElement.setAttribute("lang", htmlLang);
+  }
+
+  function applyTranslationsToDocument() {
+    updateHtmlLang();
+    updatePageTitle();
+    const elements = document.querySelectorAll("[data-i18n]");
+    elements.forEach((element) => {
+      const key = element.getAttribute("data-i18n");
+      if (!key) {
+        return;
+      }
+      setElementContent(element, key);
+    });
+    const attributeElements = document.querySelectorAll("[data-i18n-attrs]");
+    attributeElements.forEach((element) => {
+      const descriptor = element.getAttribute("data-i18n-attrs");
+      applyAttributeTranslations(element, descriptor);
+    });
+    updateLanguageToggle();
+  }
+
+  function getTargetLanguage() {
+    const available = Object.keys(translations);
+    if (available.length <= 1) {
+      return currentLanguage;
+    }
+    const currentIndex = available.indexOf(currentLanguage);
+    if (currentIndex === -1) {
+      return available[0];
+    }
+    return available[(currentIndex + 1) % available.length];
+  }
+
+  function updateLanguageToggle() {
+    const toggle = document.querySelector("[data-language-toggle]");
+    if (!toggle) {
+      return;
+    }
+    const targetLanguage = getTargetLanguage();
+    const metadata = LANGUAGE_METADATA[targetLanguage] || {};
+    const languageNames = translate("languageNames") || {};
+    const targetLanguageName = languageNames[targetLanguage] || targetLanguage;
+    const ariaLabel = translate("languageToggle.aria", { targetLanguageName });
+    const title = translate("languageToggle.title", { targetLanguageName });
+
+    toggle.setAttribute("data-target-language", targetLanguage);
+    if (ariaLabel) {
+      toggle.setAttribute("aria-label", ariaLabel);
+    }
+    if (title) {
+      toggle.setAttribute("title", title);
+    }
+
+    const flagElement = toggle.querySelector("[data-language-toggle-flag]");
+    const labelElement = toggle.querySelector("[data-language-toggle-label]");
+    if (flagElement) {
+      flagElement.textContent = metadata.flag || "";
+    }
+    if (labelElement) {
+      labelElement.textContent = metadata.label || targetLanguage.toUpperCase();
+    }
+
+    if (!toggleAttached) {
+      toggle.addEventListener("click", () => {
+        const nextLanguage = getTargetLanguage();
+        setLanguage(nextLanguage);
+      });
+      toggleAttached = true;
+    }
+  }
+
+  function notifyListeners() {
+    listeners.forEach((listener) => {
+      try {
+        listener(currentLanguage);
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  function runReadyListeners() {
+    initialized = true;
+    while (readyListeners.length > 0) {
+      const listener = readyListeners.shift();
+      try {
+        listener(currentLanguage);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+
+  function setLanguage(language) {
+    const resolved = resolveLanguage(language);
+    if (!resolved || resolved === currentLanguage) {
+      return;
+    }
+    currentLanguage = resolved;
+    storeLanguage(currentLanguage);
+    applyTranslationsToDocument();
+    notifyListeners();
+  }
+
+  function init() {
+    if (initialized) {
+      return;
+    }
+    const stored = resolveLanguage(getStoredLanguage());
+    const detected = detectBrowserLanguage();
+    currentLanguage = stored || detected || "en";
+    if (!translations[currentLanguage]) {
+      currentLanguage = "en";
+    }
+    currentPage = document.body ? document.body.getAttribute("data-page") : null;
+    applyTranslationsToDocument();
+    runReadyListeners();
+  }
+
+  const I18N = {
+    getCurrentLanguage() {
+      return currentLanguage;
+    },
+    setLanguage,
+    translate(key, params) {
+      return translate(key, params);
+    },
+    translateFor(language, key, params) {
+      const resolved = resolveLanguage(language) || currentLanguage;
+      return translateInternal(resolved, key, params);
+    },
+    formatNumber,
+    formatDateTime,
+    onChange(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    onReady(listener) {
+      if (initialized) {
+        listener(currentLanguage);
+      } else {
+        readyListeners.push(listener);
+      }
+    },
+    getLocale() {
+      return translateInternal(currentLanguage, "meta.locale") || currentLanguage;
+    },
+    getPlaceholder(key) {
+      return translate(`placeholders.${key}`);
+    },
+    translateDynamic(key, params) {
+      return translate(`dynamic.${key}`, params);
+    },
+    getTargetLanguage,
+  };
+
+  window.I18N = I18N;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- extract static and dynamic copy into a translations module with Polish and English dictionaries plus language persistence
- update the home and about pages to use data-driven translations and expose a language toggle in the header
- refresh the data loader to localise messages, re-render book cards on language changes, and tweak header styling for the new control

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68efd8e20764832b95eef63a2bdd5aaf