### PR TITLE
Fix classification of finished books

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,12 +167,27 @@ function bucketForStatus(status) {
   if (!normalized) {
     return null;
   }
+
+  let bestMatchBucket = null;
+  let bestMatchLength = 0;
+
   for (const [bucket, keywords] of Object.entries(STATUS_KEYWORDS)) {
-    if (keywords.some((keyword) => normalized.includes(keyword))) {
-      return bucket;
-    }
+    keywords.forEach((keyword) => {
+      if (!keyword) {
+        return;
+      }
+
+      if (normalized.includes(keyword)) {
+        const keywordLength = keyword.length;
+        if (keywordLength > bestMatchLength) {
+          bestMatchBucket = bucket;
+          bestMatchLength = keywordLength;
+        }
+      }
+    });
   }
-  return null;
+
+  return bestMatchBucket;
 }
 
 function createRatingElement(ratingValue) {


### PR DESCRIPTION
## Summary
- improve the status bucketing logic to prefer the most specific keyword match
- ensure finished books are placed back into the correct section instead of the current reading list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1171b5d0c832b8be356ae67ca0158