### PR TITLE
Add Insta-friendly current reading page

### DIFF
--- a/insta/index.html
+++ b/insta/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Radek czyta — Insta</title>
+    <link rel="icon" type="image/png" href="../favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body class="page-insta" data-page="insta">
+    <header class="insta-header">
+      <a class="insta-header-logo-link" href="../" aria-label="Powrót do strony głównej">
+        <img
+          src="../radek-czyta.png"
+          width="180"
+          height="180"
+          alt="Ilustracja logo Radek czyta"
+          class="insta-header-logo"
+          loading="lazy"
+        />
+      </a>
+      <p class="insta-header-title">Radek Czyta</p>
+    </header>
+
+    <main>
+      <section class="insta-books" aria-labelledby="insta-reading">
+        <h1 id="insta-reading" class="visually-hidden" data-i18n="home.sections.reading">
+          Teraz czytam
+        </h1>
+        <ul id="reading-list" class="insta-book-grid" aria-live="polite"></ul>
+        <p class="empty-message" data-for="reading-list" hidden data-i18n="home.empty">
+          Brak książek w tej sekcji.
+        </p>
+      </section>
+    </main>
+
+    <script src="../translations.js" defer></script>
+    <script src="../script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,11 @@ const STATUS_KEYWORDS = Object.freeze({
 });
 
 const I18N = window.I18N;
+const pageVariant =
+  (typeof document !== "undefined" && document.body && document.body.dataset
+    ? document.body.dataset.page
+    : null) || "home";
+const isInstaPage = pageVariant === "insta";
 
 const lists = {
   reading: document.getElementById("reading-list"),
@@ -478,6 +483,117 @@ function getCellValue(row, index) {
   return value.toString().trim();
 }
 
+function createInstaBadge(label, modifier, { icon, ariaLabel } = {}) {
+  if (!label) {
+    return null;
+  }
+
+  const text = label.toString().trim();
+  if (!text) {
+    return null;
+  }
+
+  const badge = document.createElement("span");
+  badge.className = "insta-book-badge";
+
+  if (modifier) {
+    badge.classList.add(`insta-book-badge--${modifier}`);
+  }
+
+  if (ariaLabel) {
+    badge.setAttribute("aria-label", ariaLabel);
+  }
+
+  if (icon) {
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "insta-book-badge-icon";
+    iconSpan.textContent = icon;
+    iconSpan.setAttribute("aria-hidden", "true");
+    badge.appendChild(iconSpan);
+  }
+
+  const labelSpan = document.createElement("span");
+  labelSpan.className = "insta-book-badge-label";
+  labelSpan.textContent = text;
+  badge.appendChild(labelSpan);
+
+  return badge;
+}
+
+function createInstaBookCard(
+  { title, coverUrl, format, language, genre },
+  { variant } = {}
+) {
+  const item = document.createElement("li");
+  item.className = "insta-book-card";
+
+  if (variant) {
+    item.classList.add(`insta-book-card--${variant}`);
+  }
+
+  if (coverUrl) {
+    const coverWrapper = document.createElement("div");
+    coverWrapper.className = "insta-book-cover";
+
+    const coverImage = document.createElement("img");
+    coverImage.src = coverUrl;
+    const fallbackTitle = I18N.getPlaceholder("untitled") || "";
+    const bookTitle = title || fallbackTitle || "";
+    const coverAlt = title
+      ? I18N.translateDynamic("coverAlt", { title: bookTitle })
+      : I18N.translateDynamic("coverAltFallback");
+    if (coverAlt) {
+      coverImage.alt = coverAlt;
+    }
+    coverImage.loading = "lazy";
+    coverWrapper.appendChild(coverImage);
+    item.appendChild(coverWrapper);
+  }
+
+  const metaElement = document.createElement("div");
+  metaElement.className = "insta-book-meta";
+
+  const formatInfo = getFormatDisplay(format);
+  if (formatInfo) {
+    const ariaText = I18N.translateDynamic("consumptionFormat", { label: formatInfo.label });
+    const badge = createInstaBadge(formatInfo.label, "format", {
+      icon: formatInfo.icon,
+      ariaLabel: ariaText,
+    });
+    if (badge) {
+      metaElement.appendChild(badge);
+    }
+  }
+
+  const languageInfo = getLanguageDisplay(language);
+  if (languageInfo) {
+    const labelText = languageInfo.flag ? languageInfo.label : languageInfo.originalLabel;
+    const ariaText = I18N.translateDynamic("languageAria", { label: labelText });
+    const badge = createInstaBadge(labelText, "language", {
+      icon: languageInfo.flag,
+      ariaLabel: ariaText,
+    });
+    if (badge) {
+      metaElement.appendChild(badge);
+    }
+  }
+
+  const genreBadge = createInstaBadge(genre, "genre");
+  if (genreBadge) {
+    metaElement.appendChild(genreBadge);
+  }
+
+  if (metaElement.childElementCount > 0) {
+    item.appendChild(metaElement);
+  }
+
+  if (!coverUrl && metaElement.childElementCount === 0) {
+    return null;
+  }
+
+  return item;
+}
+
 function createBookCard(
   {
     bucket,
@@ -630,7 +746,12 @@ function renderBooks() {
     }
     const fragment = document.createDocumentFragment();
     items.forEach((item) => {
-      fragment.appendChild(createBookCard(item, { variant: bucket }));
+      const card = isInstaPage
+        ? createInstaBookCard(item, { variant: bucket })
+        : createBookCard(item, { variant: bucket });
+      if (card) {
+        fragment.appendChild(card);
+      }
     });
     list.appendChild(fragment);
   });

--- a/styles.css
+++ b/styles.css
@@ -548,6 +548,153 @@ main {
   display: none;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.page-insta {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.9), rgba(234, 248, 251, 0.95));
+}
+
+body.page-insta {
+  padding: 1.25rem 1rem 1.75rem;
+  align-items: center;
+}
+
+.page-insta .insta-header {
+  width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 1.1rem;
+  text-align: center;
+}
+
+.insta-header-logo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 32px rgba(51, 51, 102, 0.18);
+  padding: 0.35rem;
+}
+
+.insta-header-logo {
+  display: block;
+  width: clamp(80px, 35vw, 110px);
+  height: auto;
+}
+
+.insta-header-title {
+  font-size: clamp(1.8rem, 7vw, 2.3rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-color);
+  margin: 0;
+}
+
+.page-insta main {
+  width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.insta-books {
+  width: 100%;
+}
+
+.insta-book-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+  gap: 0.6rem;
+}
+
+.insta-book-card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 18px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.insta-book-cover {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 10px 26px rgba(51, 51, 102, 0.18);
+}
+
+.insta-book-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.insta-book-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.insta-book-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(81, 69, 205, 0.12);
+  color: var(--accent-color);
+  font-weight: 700;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.insta-book-badge--genre {
+  background: var(--genre-tag-bg);
+  border: 1px solid var(--genre-tag-border);
+  color: var(--genre-tag-text);
+}
+
+.insta-book-badge-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.insta-book-badge-label {
+  line-height: 1;
+}
+
+.page-insta .empty-message {
+  font-size: 0.85rem;
+}
+
 .site-footer {
   margin-top: 3rem;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add a new `/insta` subpage dedicated to current reads with a simplified header
- extend the book rendering script to support an Insta layout of cover-focused cards with format/language/genre badges
- style the Insta page for a compact mobile-friendly two-by-two grid

## Testing
- No tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_69009d33a7dc832b88a30996c92c1ee6