### PR TITLE
Update Insta badges styling and language labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -386,9 +386,17 @@ function getLanguageDisplay(languageValue) {
   const languageNames = I18N.translate("languageNames") || {};
   const readable = (code && languageNames[code]) || displayText;
 
+  let shortLabel = readable;
+  if (code === "pl") {
+    shortLabel = "Pol";
+  } else if (code === "en") {
+    shortLabel = "Ang";
+  }
+
   return {
     flag,
     label: readable,
+    shortLabel,
     originalLabel: displayText,
   };
 }
@@ -567,8 +575,10 @@ function createInstaBookCard(
 
   const languageInfo = getLanguageDisplay(language);
   if (languageInfo) {
-    const labelText = languageInfo.flag ? languageInfo.label : languageInfo.originalLabel;
-    const ariaText = I18N.translateDynamic("languageAria", { label: labelText });
+    const labelText = languageInfo.flag
+      ? languageInfo.shortLabel || languageInfo.label
+      : languageInfo.originalLabel;
+    const ariaText = I18N.translateDynamic("languageAria", { label: languageInfo.label });
     const badge = createInstaBadge(labelText, "language", {
       icon: languageInfo.flag,
       ariaLabel: ariaText,

--- a/styles.css
+++ b/styles.css
@@ -666,20 +666,21 @@ body.page-insta {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.25rem 0.55rem;
-  border-radius: 999px;
-  background: rgba(81, 69, 205, 0.12);
-  color: var(--accent-color);
   font-weight: 700;
   font-size: 0.68rem;
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  color: var(--accent-color);
+  text-transform: none;
+  line-height: 1;
 }
 
 .insta-book-badge--genre {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
   background: var(--genre-tag-bg);
   border: 1px solid var(--genre-tag-border);
   color: var(--genre-tag-text);
+  text-transform: uppercase;
 }
 
 .insta-book-badge-icon {


### PR DESCRIPTION
## Summary
- remove pill background styling from Insta format and language badges while keeping the genre tag appearance
- abbreviate Polish and English language labels to "Pol" and "Ang" on the Insta page while preserving full labels for accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900a5e469b4832b85e00a1562872c00