### PR TITLE
Refine Insta dark mode styling

### DIFF
--- a/insta/index.html
+++ b/insta/index.html
@@ -13,22 +13,35 @@
     />
     <link rel="stylesheet" href="../styles.css" />
   </head>
-  <body class="page-insta" data-page="insta">
+  <body class="page-insta theme-dark" data-page="insta">
     <header class="insta-header">
-      <a class="insta-header-logo-link" href="../" aria-label="Powrót do strony głównej">
-        <img
-          src="../radek-czyta.png"
-          width="180"
-          height="180"
-          alt="Ilustracja logo Radek czyta"
-          class="insta-header-logo"
-          loading="lazy"
-        />
-      </a>
-      <p class="insta-header-title">
-        <span>Radek</span>
-        <span>Czyta</span>
-      </p>
+      <div class="insta-header-primary">
+        <a class="insta-header-logo-link" href="../" aria-label="Powrót do strony głównej">
+          <img
+            src="../radek-czyta.png"
+            width="180"
+            height="180"
+            alt="Ilustracja logo Radek czyta"
+            class="insta-header-logo"
+            loading="lazy"
+          />
+        </a>
+        <p class="insta-header-title">
+          <span>Radek</span>
+          <span>Czyta</span>
+        </p>
+      </div>
+      <button
+        type="button"
+        class="insta-theme-toggle"
+        data-theme-toggle
+        data-aria-light="Przełącz na jasny motyw"
+        data-aria-dark="Przełącz na ciemny motyw"
+        aria-label="Przełącz na jasny motyw"
+        title="Przełącz na jasny motyw"
+      >
+        <span class="insta-theme-toggle-icon" data-theme-toggle-icon aria-hidden="true">☀️</span>
+      </button>
     </header>
 
     <main>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,131 @@ const pageVariant =
     : null) || "home";
 const isInstaPage = pageVariant === "insta";
 
+const INSTA_THEME_STORAGE_KEY = "radek-insta-theme";
+const INSTA_THEMES = Object.freeze({
+  DARK: "dark",
+  LIGHT: "light",
+});
+
+function initInstaThemeToggle() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const body = document.body;
+  const toggle = document.querySelector("[data-theme-toggle]");
+
+  if (!body || !toggle) {
+    return;
+  }
+
+  const iconElement = toggle.querySelector("[data-theme-toggle-icon]");
+  const { dataset = {} } = toggle;
+
+  const fallbackAriaLabels = {
+    [INSTA_THEMES.DARK]: dataset.ariaDark || "Switch to dark theme",
+    [INSTA_THEMES.LIGHT]: dataset.ariaLight || "Switch to light theme",
+  };
+
+  function getStoredTheme() {
+    try {
+      const stored = window.localStorage.getItem(INSTA_THEME_STORAGE_KEY);
+      if (stored === INSTA_THEMES.DARK || stored === INSTA_THEMES.LIGHT) {
+        return stored;
+      }
+      return null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function storeTheme(theme) {
+    try {
+      window.localStorage.setItem(INSTA_THEME_STORAGE_KEY, theme);
+    } catch (error) {
+      // ignore storage errors
+    }
+  }
+
+  function resolveAriaLabel(theme) {
+    if (!I18N || typeof I18N.translate !== "function") {
+      return fallbackAriaLabels[theme];
+    }
+    const key =
+      theme === INSTA_THEMES.DARK
+        ? "insta.themeToggle.ariaDark"
+        : "insta.themeToggle.ariaLight";
+    return I18N.translate(key) || fallbackAriaLabels[theme];
+  }
+
+  let currentTheme = body.classList.contains("theme-light")
+    ? INSTA_THEMES.LIGHT
+    : INSTA_THEMES.DARK;
+
+  function updateTogglePresentation() {
+    const targetTheme =
+      currentTheme === INSTA_THEMES.DARK
+        ? INSTA_THEMES.LIGHT
+        : INSTA_THEMES.DARK;
+    const icon = targetTheme === INSTA_THEMES.DARK ? "🌙" : "☀️";
+    if (iconElement) {
+      iconElement.textContent = icon;
+    }
+    const ariaLabel = resolveAriaLabel(targetTheme);
+    if (ariaLabel) {
+      toggle.setAttribute("aria-label", ariaLabel);
+      toggle.setAttribute("title", ariaLabel);
+    }
+    toggle.setAttribute("data-target-theme", targetTheme);
+    toggle.setAttribute(
+      "aria-pressed",
+      currentTheme === INSTA_THEMES.DARK ? "true" : "false"
+    );
+  }
+
+  function applyTheme(theme, { skipStore = false } = {}) {
+    const nextTheme =
+      theme === INSTA_THEMES.LIGHT ? INSTA_THEMES.LIGHT : INSTA_THEMES.DARK;
+    currentTheme = nextTheme;
+    body.classList.toggle("theme-dark", nextTheme === INSTA_THEMES.DARK);
+    body.classList.toggle("theme-light", nextTheme === INSTA_THEMES.LIGHT);
+    if (!skipStore) {
+      storeTheme(nextTheme);
+    }
+    updateTogglePresentation();
+  }
+
+  const storedTheme = getStoredTheme();
+  applyTheme(storedTheme || currentTheme, { skipStore: true });
+
+  toggle.addEventListener("click", () => {
+    const targetTheme =
+      currentTheme === INSTA_THEMES.DARK
+        ? INSTA_THEMES.LIGHT
+        : INSTA_THEMES.DARK;
+    applyTheme(targetTheme);
+  });
+
+  function handleLanguageUpdate() {
+    updateTogglePresentation();
+  }
+
+  if (I18N && typeof I18N.onReady === "function") {
+    I18N.onReady(() => {
+      handleLanguageUpdate();
+      if (typeof I18N.onChange === "function") {
+        I18N.onChange(handleLanguageUpdate);
+      }
+    });
+  } else if (I18N && typeof I18N.onChange === "function") {
+    I18N.onChange(handleLanguageUpdate);
+  }
+}
+
+if (isInstaPage) {
+  initInstaThemeToggle();
+}
+
 const lists = {
   reading: document.getElementById("reading-list"),
   next: document.getElementById("next-list"),

--- a/styles.css
+++ b/styles.css
@@ -560,22 +560,128 @@ main {
   border: 0;
 }
 
-.page-insta {
-  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.9), rgba(234, 248, 251, 0.95));
-}
 
 body.page-insta {
+  --insta-light-bg: radial-gradient(
+    circle at top,
+    rgba(255, 255, 255, 0.95),
+    rgba(244, 241, 251, 0.92),
+    rgba(234, 248, 251, 0.98)
+  );
+  --insta-dark-bg: radial-gradient(
+    circle at 20% -10%,
+    rgba(80, 73, 160, 0.85) 0%,
+    rgba(25, 22, 66, 0.94) 55%,
+    rgba(9, 11, 32, 0.98) 100%
+  );
+  --insta-dark-text: #efeaff;
+  --insta-dark-muted: rgba(223, 219, 255, 0.75);
+  --insta-dark-card-shadow: 0 20px 42px rgba(8, 7, 30, 0.5);
   padding: 1.25rem 1rem 1.75rem;
   align-items: flex-start;
+  background: var(--insta-light-bg);
+  color: var(--text-color);
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+body.page-insta.theme-dark {
+  background: var(--insta-dark-bg);
+  color: var(--insta-dark-text);
+  color-scheme: dark;
+}
+
+body.page-insta.theme-dark .insta-header-title {
+  color: #f9f8ff;
+  text-shadow: 0 10px 24px rgba(4, 3, 24, 0.6);
+}
+
+body.page-insta.theme-dark .insta-header-logo-link {
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow: 0 22px 45px rgba(3, 1, 28, 0.55);
+  backdrop-filter: blur(10px);
+  border-color: rgba(255, 255, 255, 0.75);
+}
+
+body.page-insta.theme-dark .insta-header-logo {
+  filter: drop-shadow(0 18px 36px rgba(2, 0, 24, 0.55));
+}
+
+body.page-insta.theme-dark .insta-book-card {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--insta-dark-card-shadow);
+}
+
+body.page-insta.theme-dark .insta-book-cover {
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: none;
+}
+
+body.page-insta.theme-dark .empty-message {
+  color: var(--insta-dark-muted);
+}
+
+body.page-insta.theme-dark .insta-theme-toggle {
+  background: rgba(33, 30, 74, 0.65);
+  border-color: rgba(166, 158, 238, 0.4);
+  color: #f1edff;
+  box-shadow: 0 18px 36px rgba(2, 0, 30, 0.55);
+}
+
+body.page-insta.theme-dark .insta-theme-toggle:hover,
+body.page-insta.theme-dark .insta-theme-toggle:focus {
+  background: rgba(99, 90, 188, 0.7);
+  border-color: rgba(198, 191, 248, 0.55);
+}
+
+body.page-insta.theme-dark .insta-theme-toggle:focus {
+  outline-color: rgba(230, 227, 255, 0.85);
+}
+
+body.page-insta.theme-light {
+  background: var(--insta-light-bg);
+  color: var(--text-color);
+  color-scheme: light;
+}
+
+body.page-insta.theme-light .insta-header-title {
+  color: var(--accent-color);
+  text-shadow: none;
+}
+
+body.page-insta.theme-light .insta-header-logo-link {
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 32px rgba(51, 51, 102, 0.18);
+}
+
+body.page-insta.theme-light .insta-theme-toggle {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(81, 69, 205, 0.25);
+  color: var(--accent-color);
+  box-shadow: 0 12px 28px rgba(81, 69, 205, 0.18);
+}
+
+body.page-insta.theme-light .insta-theme-toggle:hover,
+body.page-insta.theme-light .insta-theme-toggle:focus {
+  background: rgba(81, 69, 205, 0.12);
 }
 
 .page-insta .insta-header {
-  width: min(480px, 100%);
+  width: min(520px, 100%);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: clamp(0.75rem, 4vw, 1.5rem);
   margin-bottom: 1.1rem;
   text-align: left;
+  flex-wrap: wrap;
+}
+
+.insta-header-primary {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 4vw, 1.5rem);
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .insta-header-logo-link {
@@ -583,10 +689,9 @@ body.page-insta {
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 12px 32px rgba(51, 51, 102, 0.18);
   padding: 0.35rem;
   flex-shrink: 0;
+  border: 2px solid transparent;
 }
 
 .insta-header-logo {
@@ -600,7 +705,6 @@ body.page-insta {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--accent-color);
   margin: 0;
   display: inline-flex;
   flex-direction: column;
@@ -608,12 +712,43 @@ body.page-insta {
   gap: 0.25rem;
 }
 
+.insta-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease,
+    color 0.25s ease, transform 0.2s ease;
+  font-family: inherit;
+  margin-left: auto;
+  align-self: flex-start;
+}
+
+.insta-theme-toggle:hover,
+.insta-theme-toggle:focus {
+  transform: translateY(-1px);
+}
+
+.insta-theme-toggle:focus {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+.insta-theme-toggle-icon {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
 .insta-header-title span {
   display: block;
 }
 
 .page-insta main {
-  width: min(480px, 100%);
+  width: min(520px, 100%);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -642,6 +777,7 @@ body.page-insta {
   align-items: center;
   gap: 0.45rem;
   box-shadow: var(--shadow-soft);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
 .insta-book-cover {
@@ -653,7 +789,8 @@ body.page-insta {
   align-items: center;
   justify-content: center;
   background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 10px 26px rgba(51, 51, 102, 0.18);
+  box-shadow: none;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
 .insta-book-cover img {

--- a/translations.js
+++ b/translations.js
@@ -46,6 +46,12 @@
             "Nie udało się pobrać danych z arkusza. Spróbuj odświeżyć stronę później.",
         },
       },
+      insta: {
+        themeToggle: {
+          ariaDark: "Przełącz na ciemny motyw",
+          ariaLight: "Przełącz na jasny motyw",
+        },
+      },
       about: {
         heading: "O mnie",
         paragraph1:
@@ -121,6 +127,12 @@
           noData: "No data to display.",
           fetchError:
             "Couldn't fetch data from the sheet. Please refresh the page later.",
+        },
+      },
+      insta: {
+        themeToggle: {
+          ariaDark: "Switch to dark theme",
+          ariaLight: "Switch to light theme",
         },
       },
       about: {


### PR DESCRIPTION
## Summary
- remove the heavy drop shadow under book covers so cards stay bright against the dark background
- restyle the Insta theme toggle as an icon-only control while keeping accessibility labels
- make the logo ring turn white in dark mode for better contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900cd5398a4832b8b11ddb2f21db109