### PR TITLE
Add reading carousel navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,35 @@
         Ładuję dane z arkusza...
       </section>
 
-      <section class="books-section" aria-labelledby="reading-now">
-        <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
-        <ul id="reading-list" class="book-list" aria-live="polite"></ul>
+      <section class="books-section books-section--reading" aria-labelledby="reading-now">
+        <div class="reading-section-header">
+          <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
+          <div class="reading-carousel-controls" data-reading-carousel-controls>
+            <button
+              type="button"
+              class="carousel-button"
+              data-reading-carousel-prev
+              aria-label="Poprzednie książki"
+              title="Poprzednie książki"
+              data-i18n-attrs="aria-label:home.carousel.prev;title:home.carousel.prev"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              class="carousel-button"
+              data-reading-carousel-next
+              aria-label="Następne książki"
+              title="Następne książki"
+              data-i18n-attrs="aria-label:home.carousel.next;title:home.carousel.next"
+            >
+              →
+            </button>
+          </div>
+        </div>
+        <div class="reading-carousel" data-reading-carousel>
+          <ul id="reading-list" class="book-list reading-carousel-list" aria-live="polite"></ul>
+        </div>
         <p class="empty-message" data-for="reading-list" hidden data-i18n="home.empty">
           Brak książek w tej sekcji.
         </p>

--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ const emptyMessages = {
   finished: document.querySelector('[data-for="finished-list"]'),
 };
 
+const READING_CAROUSEL_VISIBLE_COUNT = 3;
+
 const statusElement = document.getElementById("status-message");
 const lastUpdatedElement = document.getElementById("last-updated");
 
@@ -173,6 +175,96 @@ const state = {
   status: { key: null, params: {}, type: "info" },
   lastUpdated: null,
 };
+
+let updateReadingCarousel = null;
+
+function initReadingCarousel() {
+  if (isInstaPage) {
+    return null;
+  }
+
+  const carousel = document.querySelector("[data-reading-carousel]");
+  const list = document.getElementById("reading-list");
+  const prevButton = document.querySelector("[data-reading-carousel-prev]");
+  const nextButton = document.querySelector("[data-reading-carousel-next]");
+  const controls = document.querySelector("[data-reading-carousel-controls]");
+
+  if (!carousel || !list || !prevButton || !nextButton || !controls) {
+    return null;
+  }
+
+  const carouselState = {
+    currentIndex: 0,
+    maxIndex: 0,
+    step: 0,
+  };
+
+  function setButtonState() {
+    const isAtStart = carouselState.currentIndex <= 0;
+    const isAtEnd = carouselState.currentIndex >= carouselState.maxIndex;
+
+    prevButton.disabled = isAtStart;
+    prevButton.setAttribute("aria-disabled", isAtStart.toString());
+    nextButton.disabled = isAtEnd;
+    nextButton.setAttribute("aria-disabled", isAtEnd.toString());
+  }
+
+  function clampIndex(index) {
+    return Math.max(0, Math.min(carouselState.maxIndex, index));
+  }
+
+  function updateCarousel({ reset = false } = {}) {
+    const items = Array.from(list.children);
+    const shouldHideControls = items.length <= READING_CAROUSEL_VISIBLE_COUNT;
+
+    controls.hidden = shouldHideControls;
+
+    if (shouldHideControls || items.length === 0) {
+      carouselState.currentIndex = 0;
+      carouselState.maxIndex = 0;
+      carouselState.step = 0;
+      list.style.transform = "translateX(0px)";
+      setButtonState();
+      return;
+    }
+
+    const firstItem = items[0];
+    const firstRect = firstItem.getBoundingClientRect();
+    const listStyles = window.getComputedStyle(list);
+    const gapValue = Number.parseFloat(listStyles.columnGap || listStyles.gap || 0);
+
+    carouselState.step = firstRect.width + (Number.isFinite(gapValue) ? gapValue : 0);
+    carouselState.maxIndex = Math.max(0, items.length - READING_CAROUSEL_VISIBLE_COUNT);
+
+    if (reset) {
+      carouselState.currentIndex = 0;
+    } else {
+      carouselState.currentIndex = clampIndex(carouselState.currentIndex);
+    }
+
+    const offset = carouselState.currentIndex * carouselState.step;
+    list.style.transform = `translateX(-${offset}px)`;
+    setButtonState();
+  }
+
+  function handlePrevClick() {
+    carouselState.currentIndex = clampIndex(carouselState.currentIndex - 1);
+    updateCarousel();
+  }
+
+  function handleNextClick() {
+    carouselState.currentIndex = clampIndex(carouselState.currentIndex + 1);
+    updateCarousel();
+  }
+
+  prevButton.addEventListener("click", handlePrevClick);
+  nextButton.addEventListener("click", handleNextClick);
+  window.addEventListener("resize", () => updateCarousel());
+
+  updateCarousel({ reset: true });
+
+  return updateCarousel;
+}
 
 function applyStatus() {
   if (!statusElement) {
@@ -928,7 +1020,13 @@ function renderBooks() {
   });
 
   ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+
+  if (typeof updateReadingCarousel === "function") {
+    updateReadingCarousel({ reset: true });
+  }
 }
+
+updateReadingCarousel = initReadingCarousel();
 
 function toggleEmptyMessage(listKey) {
   const list = lists[listKey];

--- a/styles.css
+++ b/styles.css
@@ -259,6 +259,71 @@ main {
   color: var(--accent-color);
 }
 
+.books-section--reading {
+  position: relative;
+}
+
+.reading-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.reading-section-header h2 {
+  margin-bottom: 0;
+}
+
+.reading-carousel-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.carousel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(81, 69, 205, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--accent-color);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.carousel-button:hover,
+.carousel-button:focus-visible {
+  background: rgba(81, 69, 205, 0.12);
+  border-color: rgba(81, 69, 205, 0.55);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(81, 69, 205, 0.2);
+}
+
+.carousel-button:focus-visible {
+  outline: 2px solid rgba(81, 69, 205, 0.35);
+  outline-offset: 2px;
+}
+
+.carousel-button[disabled],
+.carousel-button[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.reading-carousel {
+  --reading-carousel-gap: 1rem;
+  margin-top: 1.2rem;
+  overflow: hidden;
+}
+
 .book-list {
   list-style: none;
   margin: 0;
@@ -269,9 +334,19 @@ main {
   align-items: stretch;
 }
 
-#reading-list.book-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.reading-carousel-list {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--reading-carousel-gap);
+  align-items: stretch;
+  transition: transform 0.35s ease;
+  will-change: transform;
+}
+
+.reading-carousel-list .book-card {
+  flex: 0 0 calc((100% - (var(--reading-carousel-gap) * 2)) / 3);
+  max-width: none;
+  width: auto;
 }
 
 #next-list.book-list,

--- a/translations.js
+++ b/translations.js
@@ -37,6 +37,10 @@
           next: "Następne",
           finished: "Przeczytane",
         },
+        carousel: {
+          prev: "Poprzednie książki",
+          next: "Następne książki",
+        },
         empty: "Brak książek w tej sekcji.",
         status: {
           loading: "Ładuję dane z arkusza...",
@@ -120,6 +124,10 @@
           reading: "Currently reading",
           next: "Up next",
           finished: "Finished",
+        },
+        carousel: {
+          prev: "Previous books",
+          next: "Next books",
         },
         empty: "No books in this section.",
         status: {


### PR DESCRIPTION
### Motivation
- The reading section should show three book cards and allow advancing the visible set with arrow controls so additional items slide in from the right.
- Improve accessibility by adding labelled buttons and keeping translations for new labels.

### Description
- Added carousel markup and controls to the "Teraz czytam" section in `index.html` with `data-reading-carousel`, `data-reading-carousel-prev` and `data-reading-carousel-next` attributes.
- Implemented `initReadingCarousel()` in `script.js` with `READING_CAROUSEL_VISIBLE_COUNT = 3`, per-item translateX scrolling, resize handling, and button enable/disable + `aria-disabled` management; the carousel is reset after `renderBooks()`.
- Updated styles in `styles.css` to present a horizontal, non-wrapping `.reading-carousel-list` that shows 3 cards at a time and added styles for the control buttons.
- Added translation strings for carousel button labels in `translations.js` and wired `data-i18n-attrs` for the controls.

### Testing
- Launched a local static server with `python -m http.server 8000`, which started successfully.
- Attempted an automated Playwright screenshot to verify the carousel, but the headless Chromium process crashed and the Playwright run failed (browser process SIGSEGV), so no screenshot was produced.
- No unit tests were added; the carousel is exercised via the page load flow (`renderBooks()` + `initReadingCarousel()`), and the carousel reset runs on render (manual/visual verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697792f8da98832bb631cb2d5874d76f)