### PR TITLE
Fix reading carousel layout and navigation (show max 3, side controls)

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,33 @@
         Ładuję dane z arkusza...
       </section>
 
-      <section class="books-section" aria-labelledby="reading-now">
-        <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
-        <ul id="reading-list" class="book-list" aria-live="polite"></ul>
+      <section class="books-section books-section--reading" aria-labelledby="reading-now">
+        <div class="reading-section-header">
+          <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
+        </div>
+        <div class="reading-carousel" data-reading-carousel>
+          <button
+            type="button"
+            class="carousel-button carousel-button--prev"
+            data-reading-carousel-prev
+            aria-label="Poprzednie książki"
+            title="Poprzednie książki"
+            data-i18n-attrs="aria-label:home.carousel.prev;title:home.carousel.prev"
+          >
+            ←
+          </button>
+          <ul id="reading-list" class="book-list reading-carousel-list" aria-live="polite"></ul>
+          <button
+            type="button"
+            class="carousel-button carousel-button--next"
+            data-reading-carousel-next
+            aria-label="Następne książki"
+            title="Następne książki"
+            data-i18n-attrs="aria-label:home.carousel.next;title:home.carousel.next"
+          >
+            →
+          </button>
+        </div>
         <p class="empty-message" data-for="reading-list" hidden data-i18n="home.empty">
           Brak książek w tej sekcji.
         </p>

--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ const emptyMessages = {
   finished: document.querySelector('[data-for="finished-list"]'),
 };
 
+const READING_CAROUSEL_VISIBLE_COUNT = 3;
+
 const statusElement = document.getElementById("status-message");
 const lastUpdatedElement = document.getElementById("last-updated");
 
@@ -173,6 +175,98 @@ const state = {
   status: { key: null, params: {}, type: "info" },
   lastUpdated: null,
 };
+
+let updateReadingCarousel = null;
+
+function initReadingCarousel() {
+  if (isInstaPage) {
+    return null;
+  }
+
+  const carousel = document.querySelector("[data-reading-carousel]");
+  const list = document.getElementById("reading-list");
+  const prevButton = document.querySelector("[data-reading-carousel-prev]");
+  const nextButton = document.querySelector("[data-reading-carousel-next]");
+
+  if (!carousel || !list || !prevButton || !nextButton) {
+    return null;
+  }
+
+  const carouselState = {
+    currentIndex: 0,
+    maxIndex: 0,
+    step: 0,
+  };
+
+  function setButtonState() {
+    const isAtStart = carouselState.currentIndex <= 0;
+    const isAtEnd = carouselState.currentIndex >= carouselState.maxIndex;
+
+    prevButton.hidden = isAtStart;
+    prevButton.disabled = isAtStart;
+    prevButton.setAttribute("aria-disabled", isAtStart.toString());
+    nextButton.hidden = isAtEnd;
+    nextButton.disabled = isAtEnd;
+    nextButton.setAttribute("aria-disabled", isAtEnd.toString());
+  }
+
+  function clampIndex(index) {
+    return Math.max(0, Math.min(carouselState.maxIndex, index));
+  }
+
+  function updateCarousel({ reset = false } = {}) {
+    const items = Array.from(list.children);
+    const shouldHideControls = items.length <= READING_CAROUSEL_VISIBLE_COUNT;
+
+    prevButton.hidden = shouldHideControls;
+    nextButton.hidden = shouldHideControls;
+
+    if (shouldHideControls || items.length === 0) {
+      carouselState.currentIndex = 0;
+      carouselState.maxIndex = 0;
+      carouselState.step = 0;
+      list.style.transform = "translateX(0px)";
+      setButtonState();
+      return;
+    }
+
+    const firstItem = items[0];
+    const firstRect = firstItem.getBoundingClientRect();
+    const listStyles = window.getComputedStyle(list);
+    const gapValue = Number.parseFloat(listStyles.columnGap || listStyles.gap || 0);
+
+    carouselState.step = firstRect.width + (Number.isFinite(gapValue) ? gapValue : 0);
+    carouselState.maxIndex = Math.max(0, items.length - READING_CAROUSEL_VISIBLE_COUNT);
+
+    if (reset) {
+      carouselState.currentIndex = 0;
+    } else {
+      carouselState.currentIndex = clampIndex(carouselState.currentIndex);
+    }
+
+    const offset = carouselState.currentIndex * carouselState.step;
+    list.style.transform = `translateX(-${offset}px)`;
+    setButtonState();
+  }
+
+  function handlePrevClick() {
+    carouselState.currentIndex = clampIndex(carouselState.currentIndex - 1);
+    updateCarousel();
+  }
+
+  function handleNextClick() {
+    carouselState.currentIndex = clampIndex(carouselState.currentIndex + 1);
+    updateCarousel();
+  }
+
+  prevButton.addEventListener("click", handlePrevClick);
+  nextButton.addEventListener("click", handleNextClick);
+  window.addEventListener("resize", () => updateCarousel());
+
+  updateCarousel({ reset: true });
+
+  return updateCarousel;
+}
 
 function applyStatus() {
   if (!statusElement) {
@@ -928,7 +1022,13 @@ function renderBooks() {
   });
 
   ["reading", "next", "finished"].forEach((key) => toggleEmptyMessage(key));
+
+  if (typeof updateReadingCarousel === "function") {
+    updateReadingCarousel({ reset: true });
+  }
 }
+
+updateReadingCarousel = initReadingCarousel();
 
 function toggleEmptyMessage(listKey) {
   const list = lists[listKey];

--- a/script.js
+++ b/script.js
@@ -196,18 +196,28 @@ function initReadingCarousel() {
     currentIndex: 0,
     maxIndex: 0,
     step: 0,
+    controlsHidden: false,
   };
 
   function setButtonState() {
     const isAtStart = carouselState.currentIndex <= 0;
     const isAtEnd = carouselState.currentIndex >= carouselState.maxIndex;
+    const shouldHideControls = carouselState.controlsHidden;
 
-    prevButton.hidden = isAtStart;
+    prevButton.hidden = shouldHideControls || isAtStart;
     prevButton.disabled = isAtStart;
     prevButton.setAttribute("aria-disabled", isAtStart.toString());
-    nextButton.hidden = isAtEnd;
+    prevButton.setAttribute(
+      "aria-hidden",
+      (shouldHideControls || isAtStart).toString()
+    );
+    nextButton.hidden = shouldHideControls || isAtEnd;
     nextButton.disabled = isAtEnd;
     nextButton.setAttribute("aria-disabled", isAtEnd.toString());
+    nextButton.setAttribute(
+      "aria-hidden",
+      (shouldHideControls || isAtEnd).toString()
+    );
   }
 
   function clampIndex(index) {
@@ -218,8 +228,7 @@ function initReadingCarousel() {
     const items = Array.from(list.children);
     const shouldHideControls = items.length <= READING_CAROUSEL_VISIBLE_COUNT;
 
-    prevButton.hidden = shouldHideControls;
-    nextButton.hidden = shouldHideControls;
+    carouselState.controlsHidden = shouldHideControls;
 
     if (shouldHideControls || items.length === 0) {
       carouselState.currentIndex = 0;

--- a/styles.css
+++ b/styles.css
@@ -259,6 +259,83 @@ main {
   color: var(--accent-color);
 }
 
+.books-section--reading {
+  position: relative;
+}
+
+.reading-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.reading-section-header h2 {
+  margin-bottom: 0;
+}
+
+.carousel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(81, 69, 205, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--accent-color);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+}
+
+.carousel-button:hover,
+.carousel-button:focus-visible {
+  background: rgba(81, 69, 205, 0.12);
+  border-color: rgba(81, 69, 205, 0.55);
+  transform: translateY(calc(-50% - 1px));
+  box-shadow: 0 8px 18px rgba(81, 69, 205, 0.2);
+}
+
+.carousel-button:focus-visible {
+  outline: 2px solid rgba(81, 69, 205, 0.35);
+  outline-offset: 2px;
+}
+
+.carousel-button[disabled],
+.carousel-button[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: translateY(-50%);
+}
+
+.carousel-button[hidden] {
+  display: none;
+}
+
+.carousel-button--prev {
+  left: -0.6rem;
+}
+
+.carousel-button--next {
+  right: -0.6rem;
+}
+
+.reading-carousel {
+  --reading-carousel-gap: 1rem;
+  margin-top: 1.2rem;
+  overflow: hidden;
+  position: relative;
+  padding: 0 1.4rem;
+}
+
 .book-list {
   list-style: none;
   margin: 0;
@@ -269,9 +346,20 @@ main {
   align-items: stretch;
 }
 
-#reading-list.book-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.reading-carousel-list {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--reading-carousel-gap);
+  align-items: stretch;
+  transition: transform 0.35s ease;
+  will-change: transform;
+  width: 100%;
+}
+
+.reading-carousel-list .book-card {
+  flex: 0 0 calc((100% - (var(--reading-carousel-gap) * 2)) / 3);
+  max-width: none;
+  width: auto;
 }
 
 #next-list.book-list,

--- a/translations.js
+++ b/translations.js
@@ -37,6 +37,10 @@
           next: "Następne",
           finished: "Przeczytane",
         },
+        carousel: {
+          prev: "Poprzednie książki",
+          next: "Następne książki",
+        },
         empty: "Brak książek w tej sekcji.",
         status: {
           loading: "Ładuję dane z arkusza...",
@@ -120,6 +124,10 @@
           reading: "Currently reading",
           next: "Up next",
           finished: "Finished",
+        },
+        carousel: {
+          prev: "Previous books",
+          next: "Next books",
         },
         empty: "No books in this section.",
         status: {


### PR DESCRIPTION
### Motivation
- The reading carousel previously showed all items and placed navigation controls in the header, which did not match expected behavior of showing up to three cards and scrolling by one card with side arrows. 
- Controls must be colocated with the carousel at the sides, hide when not applicable, and move the visible set by a single card per click.

### Description
- Moved carousel controls into the carousel markup in `index.html` and added `carousel-button--prev`/`--next` classes with `data-reading-carousel-prev`/`data-reading-carousel-next` attributes. 
- Introduced `initReadingCarousel()` and `READING_CAROUSEL_VISIBLE_COUNT = 3` in `script.js` which computes per-item `step` from item width+gap, clamps `currentIndex`, applies `transform: translateX(...)` to scroll by one book, hides/shows buttons when at start/end or when items <= visible count, and wires resize handling and reset on `renderBooks()`. 
- Updated `styles.css` to position circular side buttons absolutely (vertically centered), hide buttons via `[hidden]`, make `.reading-carousel-list` a non-wrapping flex row sized for 3 visible cards (`flex: 0 0 calc(...)`), and add spacing/padding so controls align with card edges. 
- Added translation strings for the carousel labels in `translations.js` and wired `data-i18n-attrs` on the controls.

### Testing
- Ran an automated Playwright script that loaded the page and captured a screenshot (`artifacts/reading-carousel.png`), and the run produced the screenshot successfully. 
- No unit tests were added for the carousel behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697792f8da98832bb631cb2d5874d76f)