### PR TITLE
Position reading carousel controls as overlay and hide/show arrows correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,10 +69,12 @@
       <section class="books-section books-section--reading" aria-labelledby="reading-now">
         <div class="reading-section-header">
           <h2 id="reading-now" data-i18n="home.sections.reading">Teraz czytam</h2>
+        </div>
+        <div class="reading-carousel" data-reading-carousel>
           <div class="reading-carousel-controls" data-reading-carousel-controls>
             <button
               type="button"
-              class="carousel-button"
+              class="carousel-button carousel-button--prev"
               data-reading-carousel-prev
               aria-label="Poprzednie książki"
               title="Poprzednie książki"
@@ -82,7 +84,7 @@
             </button>
             <button
               type="button"
-              class="carousel-button"
+              class="carousel-button carousel-button--next"
               data-reading-carousel-next
               aria-label="Następne książki"
               title="Następne książki"
@@ -91,8 +93,6 @@
               →
             </button>
           </div>
-        </div>
-        <div class="reading-carousel" data-reading-carousel>
           <ul id="reading-list" class="book-list reading-carousel-list" aria-live="polite"></ul>
         </div>
         <p class="empty-message" data-for="reading-list" hidden data-i18n="home.empty">

--- a/script.js
+++ b/script.js
@@ -199,7 +199,7 @@ function initReadingCarousel() {
     step: 0,
   };
 
-  function setButtonState() {
+  function setButtonState({ shouldHideControls = false } = {}) {
     const isAtStart = carouselState.currentIndex <= 0;
     const isAtEnd = carouselState.currentIndex >= carouselState.maxIndex;
 
@@ -207,6 +207,15 @@ function initReadingCarousel() {
     prevButton.setAttribute("aria-disabled", isAtStart.toString());
     nextButton.disabled = isAtEnd;
     nextButton.setAttribute("aria-disabled", isAtEnd.toString());
+
+    if (shouldHideControls) {
+      prevButton.hidden = true;
+      nextButton.hidden = true;
+      return;
+    }
+
+    prevButton.hidden = isAtStart;
+    nextButton.hidden = isAtEnd;
   }
 
   function clampIndex(index) {
@@ -224,7 +233,7 @@ function initReadingCarousel() {
       carouselState.maxIndex = 0;
       carouselState.step = 0;
       list.style.transform = "translateX(0px)";
-      setButtonState();
+      setButtonState({ shouldHideControls });
       return;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -263,22 +263,22 @@ main {
   position: relative;
 }
 
-.reading-section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
 .reading-section-header h2 {
   margin-bottom: 0;
 }
 
 .reading-carousel-controls {
-  display: inline-flex;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  padding: 0 0.25rem;
+  transform: translateY(-50%);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .carousel-button {
@@ -295,6 +295,7 @@ main {
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
     box-shadow 0.2s ease;
+  pointer-events: auto;
 }
 
 .carousel-button:hover,
@@ -320,6 +321,7 @@ main {
 
 .reading-carousel {
   --reading-carousel-gap: 1rem;
+  position: relative;
   margin-top: 1.2rem;
   overflow: hidden;
 }


### PR DESCRIPTION
### Motivation
- Improve the reading carousel UX by placing navigation controls on the carousel edges and ensuring controls are only visible when needed.
- Ensure the carousel shows at most `3` visible items and that the prev/next arrows navigate the list by one item and hide when at the ends.

### Description
- Move carousel buttons into the carousel markup so they overlay the list (`index.html` changes adding `carousel-button--prev` and `carousel-button--next`).
- Position controls as an absolute overlay and allow clicks to pass through to the buttons while keeping the layout intact (`styles.css` changes adding absolute positioning, centering, `pointer-events` adjustments and `position: relative` on the carousel).
- Update carousel logic in `initReadingCarousel()` (`script.js`) to accept `shouldHideControls`, hide buttons (using `hidden`) when not needed, and keep previous enable/disable behavior for accessibility via `aria-disabled` and `disabled`.

### Testing
- Started a local server with `python -m http.server 8000` and it served the site successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and captured a full-page screenshot; the script completed and produced `artifacts/reading-carousel.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ab30ab28832bb09473a336166252)