### PR TITLE
Fix missing homepage review links for generated markdown reviews

### DIFF
--- a/recenzje/reviews-manifest.json
+++ b/recenzje/reviews-manifest.json
@@ -1,0 +1,10 @@
+{
+  "generatedAt": "2026-02-15T19:36:55.994506Z",
+  "slugs": [
+    "a-court-of-thorns-and-roses-sarah-j-maas",
+    "children-of-time-adrian-tchaikovsky",
+    "cien-endera-orson-scott-card",
+    "natychmiast-to-skasuj-konrad-hildebrand",
+    "predkosc-mroku-elizabeth-moon"
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 const SHEET_CSV_URL =
   "https://docs.google.com/spreadsheets/d/e/2PACX-1vQjjjgtBTUiSTuLiJQ_rP4m7uYffLK_uvkF2Dt1_NildFjEHUcilVUysEQRBH-iWJC1dA-Rtpx8tVn8/pub?gid=2028690260&single=true&output=csv";
+const REVIEW_MANIFEST_URL = "/recenzje/reviews-manifest.json";
 
 const SHEET_COLUMN_INDEXES = Object.freeze({
   title: 2, // kolumna C
@@ -175,6 +176,7 @@ const state = {
   books: [],
   status: { key: null, params: {}, type: "info" },
   lastUpdated: null,
+  reviewSlugs: new Set(),
 };
 
 let updateReadingCarousel = null;
@@ -1092,6 +1094,7 @@ async function loadBooks() {
   try {
     showStatus("home.status.loading");
     setLastUpdated(null);
+    await loadReviewManifest();
     const response = await fetch(SHEET_CSV_URL, { cache: "no-store" });
     if (!response.ok) {
       const error = new Error("HTTP_ERROR");
@@ -1132,7 +1135,8 @@ async function loadBooks() {
         return;
       }
 
-      const reviewSlug = review ? slugify(title, author) : "";
+      const reviewSlug = slugify(title, author);
+      const hasReview = Boolean(review) || state.reviewSlugs.has(reviewSlug);
       const reviewUrl = reviewSlug ? `/recenzje/${reviewSlug}.html` : null;
 
       items.push({
@@ -1147,7 +1151,7 @@ async function loadBooks() {
         format,
         language,
         progress,
-        reviewUrl,
+        reviewUrl: hasReview ? reviewUrl : null,
       });
     });
 
@@ -1173,6 +1177,30 @@ async function loadBooks() {
     } else {
       showStatus("home.status.fetchError", {}, "error");
     }
+  }
+}
+
+async function loadReviewManifest() {
+  try {
+    const response = await fetch(REVIEW_MANIFEST_URL, { cache: "no-store" });
+    if (!response.ok) {
+      state.reviewSlugs = new Set();
+      return;
+    }
+
+    const payload = await response.json();
+    if (!payload || !Array.isArray(payload.slugs)) {
+      state.reviewSlugs = new Set();
+      return;
+    }
+
+    state.reviewSlugs = new Set(
+      payload.slugs
+        .map((slug) => (typeof slug === "string" ? slug.trim() : ""))
+        .filter(Boolean)
+    );
+  } catch (error) {
+    state.reviewSlugs = new Set();
   }
 }
 

--- a/scripts/generate-reviews.mjs
+++ b/scripts/generate-reviews.mjs
@@ -972,6 +972,13 @@ async function generateReviews() {
 
   await Promise.all(writeTasks);
 
+  const manifestPath = path.join(outputDir, "reviews-manifest.json");
+  const uniqueSlugs = Array.from(new Set(generated.map(({ slug }) => slug))).sort();
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify({ generatedAt: new Date().toISOString(), slugs: uniqueSlugs }, null, 2)}\n`
+  );
+
   console.log(`Generated ${generated.length} review page(s) in ${REVIEW_OUTPUT_DIR}/`);
   generated.forEach(({ slug, outputFile }) => {
     console.log(`- ${slug}: ${path.relative(outputRoot, outputFile)}`);


### PR DESCRIPTION
### Motivation
- Homepage nie pokazywała przycisku „Przeczytaj recenzję” dla recenzji wygenerowanych z plików Markdown, jeśli kolumna `review` w Google Sheets była pusta.
- Potrzebne było wykrycie recenzji również na podstawie istniejących stron w `recenzje/`, aby linki były widoczne niezależnie od zawartości arkusza.

### Description
- Dodano ładowanie manifestu recenzji pod ścieżką `'/recenzje/reviews-manifest.json'` i przechowywanie slugów w `state.reviewSlugs` w `script.js`.
- Zmieniono logikę przy tworzeniu `reviewUrl`, aby przycisk był pokazany, gdy kolumna `review` w arkuszu ma wartość lub gdy slug występuje w manifestie (`state.reviewSlugs`).
- Zaktualizowano `scripts/generate-reviews.mjs`, aby po wygenerowaniu stron recenzji zapisywał `recenzje/reviews-manifest.json` z listą slugów i znacznikiem `generatedAt`.
- Dodano aktualny plik manifestu `recenzje/reviews-manifest.json` do repozytorium jako bieżący stan generowanych recenzji.

### Testing
- Uruchomiono `node --check script.js` i rezultat był pozytywny (no syntax errors).
- Uruchomiono `node --check scripts/generate-reviews.mjs` i wynik był pozytywny (no syntax errors).
- Weryfikowano lokalnie przez serwer HTTP uruchomiony z `python3 -m http.server 4173 --directory /workspace/reading-now` i żądanie do strony zwróciło serwis (visual check).
- Wykonano zrzut ekranu strony głównej przez Playwright aby potwierdzić obecność przycisków recenzji i zrzut zakończył się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921fd739a0832b81b3c9fc5849cb4e)